### PR TITLE
docs: add CI fix guide header and clarify test requirements

### DIFF
--- a/.github/ai-fix-prompt.md
+++ b/.github/ai-fix-prompt.md
@@ -1,3 +1,5 @@
+# CI Fix Guide
+
 If CI fails:
 
 1. Read workflow logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,8 @@ DO NOT:
 ALWAYS:
 
 - run bun run build before committing
-- ensure bun run test passes
-- ensure pytest passes
+- ensure bun run test passes (if configured)
+- ensure pytest passes (if configured)
 - prefer minimal edits
 
 ## CI definition


### PR DESCRIPTION
**コミット詳細:**

- `.github/ai-fix-prompt.md`: 「CI Fix Guide」の見出しを追加
- `CLAUDE.md`: テスト実行の指示を「(if configured)」に緩和