### PR TITLE
docs: update migration log and add site-url utility JSDoc & tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,5 @@ legacy/
 .claude/settings.local.json
 
 pricing_old.json
-archive
+/archive/
 md-for-update

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -196,17 +196,17 @@ Phase E の確立パターン（MermaidDiagram）:
 - bash 配列変数 `${...}` / GitHub Actions `${{ }}` は `// biome-ignore lint/suspicious/noTemplateCurlyInString:` で抑制
 - lint 既知違反: なし（全解消 ✅）
 
-作業手順（Phase F: redirects / sitemap）:
+Phase F — 実施ログ（参考）:
 - ※ Phase F 完了済み。URL マッピングは `docs/archive/NEXTJS_PHASE_A_F_PLAN.md` §Phase F を参照
-- Phase F は以下の 2 タスクで構成される:
-  1. `netlify.toml` に `[[redirects]]` を追加（旧 `.html` URL → 新 Next.js パス、301）
-  2. `web-next/public/sitemap.xml`（または `app/sitemap.ts`）を更新して移行済み全ページを列挙
-- 各タスク完了ごとに以下を順に実行 → 全部 OK なら 1 コミット:
-  1. (cd web-next && bun run build)     # 全ルートが ○ (Static) であること
-  2. (cd web-next && bunx biome check --write netlify.toml)  # ← R1: パス指定必須
-  3. (cd web-next && bun run test)       # 全件が pass することを確認
-  4. git add netlify.toml web-next/public/sitemap.xml && git commit -m "feat(web-next): Phase F — add redirects/sitemap for legacy HTML cutover"
-  5. **MIGRATION_PROGRESS.md を更新 → git commit**（HEAD・次の作業・テスト数・ビルドを同期）
+- 完了した 2 タスク:
+  1. `netlify.toml` に `[[redirects]]` を追加（旧 `.html` URL → 新 Next.js パス、301） [✅ Done: 2026-05-09 11:39:07, `5510c4e`]
+  2. `web-next/public/sitemap.xml` の静的配置に代わり、`web-next/app/sitemap.ts` (および `robots.ts`) を実装して移行済み全ページを動的に列挙 [✅ Done: 2026-05-09 11:39:07, `5510c4e`]
+- 実行済みのチェックリスト:
+  1. (cd web-next && bun run build) # 全ルート Static 検証 [✅ Done: 2026-05-09 11:39:07]
+  2. (cd web-next && bunx biome check --write netlify.toml) [✅ Done: 2026-05-09 11:39:07]
+  3. (cd web-next && bun run test) # 全件 pass 検証 [✅ Done: 2026-05-09 11:39:07]
+  4. git add とコミット [✅ Done: 2026-05-09 11:39:07, `5510c4e`]
+  5. MIGRATION_PROGRESS.md の更新とコミット [✅ Done: 2026-05-09 11:40:21, `e2603c1`]
 
 絶対禁止:
 - bun run lint:fix / bunx biome check --write （パス引数なし） — リポジトリ全体を書き換えるため（R1 違反）

--- a/web-next/lib/site-url.test.ts
+++ b/web-next/lib/site-url.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSiteUrl } from "./site-url";
+
+describe("resolveSiteUrl", () => {
+  const DEFAULT_SITE_URL = "https://comparison-of-llms.netlify.app";
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env;
+    process.env = { ...originalEnv };
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("returns URL.origin when NEXT_PUBLIC_SITE_URL is valid", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://custom.example.com/path";
+    const result = resolveSiteUrl("robots.ts");
+    expect(result).toBe("https://custom.example.com");
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to DEFAULT_SITE_URL and does not throw when NEXT_PUBLIC_SITE_URL is invalid", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "not-a-valid-url";
+    process.env.NETLIFY = "true"; // Prevent warn for missing Netlify
+    const result = resolveSiteUrl("sitemap.ts");
+    expect(result).toBe(DEFAULT_SITE_URL);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns DEFAULT_SITE_URL and warns when NEXT_PUBLIC_SITE_URL is undefined on non-Netlify", () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    delete process.env.NETLIFY;
+    const result = resolveSiteUrl("robots.ts");
+    expect(result).toBe(DEFAULT_SITE_URL);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[robots.ts] NEXT_PUBLIC_SITE_URL is not set or invalid.")
+    );
+  });
+
+  it("returns DEFAULT_SITE_URL and does not warn when NEXT_PUBLIC_SITE_URL is undefined on Netlify", () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    process.env.NETLIFY = "true";
+    const result = resolveSiteUrl("sitemap.ts");
+    expect(result).toBe(DEFAULT_SITE_URL);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/web-next/lib/site-url.ts
+++ b/web-next/lib/site-url.ts
@@ -1,5 +1,16 @@
 const DEFAULT_SITE_URL = "https://comparison-of-llms.netlify.app";
 
+/**
+ * Resolve the site URL from environment variables or use a default fallback.
+ *
+ * Prefers `NEXT_PUBLIC_SITE_URL` and validates it using the URL constructor.
+ * If parsing fails or the variable is unset, falls back to `DEFAULT_SITE_URL`.
+ * Invalid `NEXT_PUBLIC_SITE_URL` values will be ignored (no exception thrown).
+ * Emits a warning for non-`NETLIFY` deployments when the environment variable is missing.
+ *
+ * @param caller - The name of the calling module (allowed values: "robots.ts" | "sitemap.ts"). Used only for contextual warning messages.
+ * @returns The resolved site origin string (scheme + host + port).
+ */
 export function resolveSiteUrl(caller: "robots.ts" | "sitemap.ts"): string {
   const envVal = process.env.NEXT_PUBLIC_SITE_URL;
   if (envVal) {


### PR DESCRIPTION
主にサイトURL解決ユーティリティの改善とテストの追加、
  および移行進捗ドキュメントの更新です。

  具体的には以下の変更が行われました：

  1. web-next/lib/site-url.ts の改善
   * JSDocの追加: resolveSiteUrl
     関数の仕様（環境変数の優先順位、バリデーション、フォールバック挙
     動、警告の条件など）を明文化しました。
   * 挙動の整理: NEXT_PUBLIC_SITE_URL
     が無効な場合でも例外を投げず、デフォルト値にフォールバックするよ
     うに設計されています。

  2. web-next/lib/site-url.test.ts の新規作成
   * resolveSiteUrl に対するユニットテストを実装しました。
       * 有効なURLが設定されている場合の正常系テスト。
       * 無効なURLや未設定時のフォールバックテスト。
       * Netlify環境かどうかに応じた警告（console.warn）の出力制御の
         検証。

  3. MIGRATION_PROGRESS.md の更新
   * Phase F の実施ログを整理:
     これまで「手順」として記載されていた内容を、実際に完了した「ログ
     」として書き換えました。
   * 各タスク（リダイレクト設定、sitemap.tsの実装など）の完了日時とコ
     ミットハッシュを追記し、進捗状況を固定しました。

  4. .gitignore の微調整
   * archive ディレクトリの指定を /archive/
     に変更し、パス指定をより厳密にしました。