### PR TITLE
「ページレジストリ（page-registry）によるメタデータの一元管理」と、それに伴う機能実装およびインフラ調整

### DIFF
--- a/.claude/skills/monthly-update/SKILL.md
+++ b/.claude/skills/monthly-update/SKILL.md
@@ -93,7 +93,7 @@ AIモデル価格と為替レートを一括更新します。
 ```bash
 cd web-next
 grep -n -A3 'slug: "/claude/agent"' lib/page-registry.ts   # 該当エントリを特定
-# lastReviewed: "2026-06-30" → lastReviewed: "2026-07-13" に書き換える
+# lastReviewed: "<旧確認日>" → lastReviewed: "<確認日 YYYY-MM-DD>" に書き換える
 ```
 
 - この値がサイト上部の鮮度バッジ（`PageFreshness`）と `/whats-new`、`sitemap.xml` の `lastmod` に

--- a/.claude/skills/monthly-update/SKILL.md
+++ b/.claude/skills/monthly-update/SKILL.md
@@ -9,7 +9,7 @@ Trigger: 月次更新, 価格アップデート, monthly update, 価格改定の
 
 # 月次更新・メンテナンススキル
 
-(最終更新日: 2026-07-01)
+(最終更新日: 2026-07-13)
 
 ## Goal
 
@@ -84,6 +84,24 @@ AIモデル価格と為替レートを一括更新します。
   2. **JSX の半角スペース消失**: テキストと `<strong>` / `<Ext>` が改行で隣接すると空白が消える。直前/直後に `{" "}` を明示挿入する。
   3. **契約テストの完全一致**: `page.test.tsx` は `toBe`（完全一致）と `toContain/toMatch` が混在。metadata description 等を変えたら同一コミットでテストも同期。編集前に `grep -nE 'toBe\(|toContain|toMatch' app/<path>/page.test.tsx`。
   4. **コミット前の最終スイープ**: 前月表記（例: `2026年5月` / `May 2026`）が残っていないか grep して空になるまで潰す。
+
+### 4.5. ページレジストリの `lastReviewed` 書き戻し（必須・F-2'）
+
+**1 ページの内容確認が終わるたびに**、`web-next/lib/page-registry.ts` の該当エントリの
+`lastReviewed` を**確認を行った当日の日付（YYYY-MM-DD）**へ更新する。
+
+```bash
+cd web-next
+grep -n -A3 'slug: "/claude/agent"' lib/page-registry.ts   # 該当エントリを特定
+# lastReviewed: "2026-06-30" → lastReviewed: "2026-07-13" に書き換える
+```
+
+- この値がサイト上部の鮮度バッジ（`PageFreshness`）と `/whats-new`、`sitemap.xml` の `lastmod` に
+  そのまま出る。**月次確認の完了 = registry 更新 = 鮮度表示の更新** が 1 コミットで閉じる設計
+  （plans/006 §4）
+- 内容に変更がなくても「確認した」事実として `lastReviewed` は更新する。
+  `addedAt`（公開日）は**絶対に変更しない**
+- 確認しなかったページの `lastReviewed` は触らない（古いまま表示されるのが正しい振る舞い）
 
 ### 5. ローカル静的検証 & テスト
 

--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,4 @@ legacy/
 pricing_old.json
 /archive/
 md-for-update
-/plans/
+# /plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ Playwright ブラウザバイナリ（`/root/.cache/ms-playwright/`）はバイ�
 
 - **Next.js 16 App Router + SSG**: `output: 'export'` で pure 静的エクスポート → Netlify CDN 配信。`@netlify/plugin-nextjs` 不要。Phase 1–14 でコスト計算機ホームが移行済、Phase A–F で残 18 ガイドページも全移行完了（計画書は `docs/archive/` に保存）。さらに `/google/agent-harness-engineering` や `/google/adk-best-practices`、`/google/stitch-guide`、`/claude/managed-agents`、`/claude/self-hosted-sandboxes`、`/claude/code-slash-commands`、`/claude/fable-5-best-practices`、`/claude/skills-sh`、`/code-review/coderabbit-guide`、`/code-review/copilot-code-review`、`/code-review/sonar-qube`、`/code-review/tool-pricing`、`/agent/hermes-agent-advanced-guide`、`/agent/skills`、`/security/ai-security-best-practices`、/local-llm/best-practices、/ci-cd/ai-cicd-automation-best-practices、/agent/context-engineering-best-practices、/multimodal/image-audio-best-practices-2026、/llm-ops/evaluation-observability ページを追加
 - **ページレジストリ（`web-next/lib/page-registry.ts`）が全ページメタデータの SSoT**: 鮮度表示（`PageFreshness`）・What's New（`/whats-new`）・`sitemap.ts` はすべて registry から導出する。属性を nav-links や各 page.tsx に複製しない（複製した結果 sitemap が 24/55 ルートで腐った経緯がある）。**新規ページを追加したら registry への登録が必須** — `web-next/tests/page-registry-coverage.test.ts` が登録漏れ・幽霊エントリを機械検知する。`lastReviewed`（最終確認日）は月次更新で当日日付へ書き戻す（`.claude/skills/monthly-update/`）
+- **page.tsx は Server Component に保つ（metadata の前提）**: Next.js の規約により `"use client"` なファイルは `export const metadata` を持てない。スクロール監視等のクライアント処理は `TocObserver.tsx` 等へ切り出し、page.tsx 自体は Server Component に保つこと。已に全体が `"use client"` になっている `/code-review/coderabbit-guide` と `/code-review/sonar-qube` は、例外的にルート単位の `layout.tsx` から metadata を供給している
 - **3層フォールバック**: スクレイパーは「スクレイプ成功 → 既存 JSON の値 → ハードコードフォールバック」の順で価格を決定。`scrape_status` フィールド (`success` | `fallback` | `manual`) で出自を追跡
 - **型の同期**: `scraper/src/scraper/models.py` (Pydantic) が SSoT、`web-next/types/pricing.ts` (TypeScript) が手動ミラー、`web-next/lib/pricing.ts` の `_AssertParity` でコンパイル時検証。**片方を変更したら必ずもう片方も更新すること**
 - **JA/EN バイリンガル**: `web-next/lib/i18n.tsx` で全テキストを管理（`T` オブジェクト + `t()` / `tRich()` の React 要素ファクトリ）。各スクレイパーも `sub_ja` / `sub_en` や `note_ja` / `note_en` のペアで日英テキストを持つ。ガイドページ（Phase B–E）は当面 JA 固定
@@ -265,7 +266,7 @@ Build:     cd web-next && bun run build
 以下を全て確認してからコミットすること：
 
 1. `cd web-next && bun run build` が成功（※Antigravityサンドボックス環境では実行禁止。他環境やCIでは必須）
-2. `cd web-next && bun run test` が成功（実測 1040 件合格を確認）
+2. `cd web-next && bun run test` が成功（実測 1046 件合格を確認）
 3. `cd web-next && bun run typecheck` が成功
 4. `cd web-next && bun run lint` が成功（既知の違反件数は CI または進捗ドキュメントを参照、新規違反がないこと）
 5. `cd scraper && uv run pytest` が成功

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Updated 2026-07-12
+Updated 2026-07-13
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -22,15 +22,18 @@ update.sh  ← オーケストレーター (scrape → copy)
 │       └── tools/               コーディングツール別スクレイパー (cursor, github_copilot, windsurf, claude_code, jetbrains, openai_codex, google_one, antigravity)
 ├── web-next/           Next.js 16 + React 19 + TypeScript + Tailwind v4 (bun)
 │   ├── app/
-│   │   ├── layout.tsx           ルートレイアウト (SiteHeader/DisclaimerBanner マウント済み)
+│   │   ├── layout.tsx           ルートレイアウト (SiteHeader/DisclaimerBanner/PageFreshness マウント済み)
 │   │   ├── page.tsx             コスト計算機ホーム (Server Component + Zod 検証 → HomePage へ委譲)
+│   │   ├── sitemap.ts           page-registry から全ルートを導出 (lastmod = lastReviewed)
+│   │   ├── whats-new/           What's New (新着 / 最近更新を page-registry から静的生成)
 │   │   ├── globals.css          Tailwind v4 + legacy design tokens (227 行)
 │   │   └── {claude,google,codex,copilot}/{skill,agent}/ および /google/agent-harness-engineering/、/google/notebook-lm/、/google/adk-best-practices/、/google/stitch-guide/、/claude/managed-agents/、/claude/self-hosted-sandboxes/、/claude/code-slash-commands/、/claude/fable-5-best-practices/、/claude/skills-sh/、/mcp/mcp-best-practices/、/mcp/mcp-best-practices-intermediate/、/code-review/coderabbit-guide/、/code-review/copilot-code-review/、/code-review/sonar-qube/、/code-review/tool-pricing/、/agent/hermes-agent-advanced-guide/、/agent/loop-engineering/、/agent/skills/、/vercel/sandbox/、/cursor/complete-guide/、/cursor/complete-guide-intermediate/、/security/ai-security-best-practices/、/security/ai-security-best-practices-intermediate/、/local-llm/self-hosting/、/local-llm/best-practices/、/ci-cd/ai-cicd-automation-best-practices/、/agent/context-engineering-best-practices/、/rag/embeddings-best-practices/、/multimodal/generation-best-practices/、/multimodal/image-audio-best-practices-2026/、/llm-ops/evaluation-observability/   Phase B–C および追加移行済みルート（詳細は [`docs/archive/MIGRATION_PROGRESS.md`](docs/archive/MIGRATION_PROGRESS.md)）
 │   ├── components/
 │   │   ├── HomePage.tsx         Client Component (Phase 10)
 │   │   ├── ApiTable.tsx / SubTable.tsx / Hero.tsx / ...   (Phase 8-10 成果物)
-│   │   └── site/                Phase A 共通インフラ（追加済み） (SiteHeader, DisclaimerBanner, nav-links)
+│   │   └── site/                Phase A 共通インフラ（追加済み） (SiteHeader, DisclaimerBanner, PageFreshness, nav-links)
 │   ├── lib/
+│   │   ├── page-registry.ts     全ページのメタデータ SSoT (Zod / 鮮度表示・What's New・sitemap の導出元)
 │   │   ├── cost.ts              純粋関数 (calcApiCost / calcSubCost / colorIndex / fmtUSD / fmtJPY)
 │   │   ├── pricing.ts           Zod スキーマ + コンパイル時パリティアサート
 │   │   ├── i18n.tsx             T オブジェクト + t() + tRich() (React 要素ファクトリ)
@@ -183,6 +186,7 @@ Playwright ブラウザバイナリ（`/root/.cache/ms-playwright/`）はバイ�
 ## 重要な設計判断
 
 - **Next.js 16 App Router + SSG**: `output: 'export'` で pure 静的エクスポート → Netlify CDN 配信。`@netlify/plugin-nextjs` 不要。Phase 1–14 でコスト計算機ホームが移行済、Phase A–F で残 18 ガイドページも全移行完了（計画書は `docs/archive/` に保存）。さらに `/google/agent-harness-engineering` や `/google/adk-best-practices`、`/google/stitch-guide`、`/claude/managed-agents`、`/claude/self-hosted-sandboxes`、`/claude/code-slash-commands`、`/claude/fable-5-best-practices`、`/claude/skills-sh`、`/code-review/coderabbit-guide`、`/code-review/copilot-code-review`、`/code-review/sonar-qube`、`/code-review/tool-pricing`、`/agent/hermes-agent-advanced-guide`、`/agent/skills`、`/security/ai-security-best-practices`、/local-llm/best-practices、/ci-cd/ai-cicd-automation-best-practices、/agent/context-engineering-best-practices、/multimodal/image-audio-best-practices-2026、/llm-ops/evaluation-observability ページを追加
+- **ページレジストリ（`web-next/lib/page-registry.ts`）が全ページメタデータの SSoT**: 鮮度表示（`PageFreshness`）・What's New（`/whats-new`）・`sitemap.ts` はすべて registry から導出する。属性を nav-links や各 page.tsx に複製しない（複製した結果 sitemap が 24/55 ルートで腐った経緯がある）。**新規ページを追加したら registry への登録が必須** — `web-next/tests/page-registry-coverage.test.ts` が登録漏れ・幽霊エントリを機械検知する。`lastReviewed`（最終確認日）は月次更新で当日日付へ書き戻す（`.claude/skills/monthly-update/`）
 - **3層フォールバック**: スクレイパーは「スクレイプ成功 → 既存 JSON の値 → ハードコードフォールバック」の順で価格を決定。`scrape_status` フィールド (`success` | `fallback` | `manual`) で出自を追跡
 - **型の同期**: `scraper/src/scraper/models.py` (Pydantic) が SSoT、`web-next/types/pricing.ts` (TypeScript) が手動ミラー、`web-next/lib/pricing.ts` の `_AssertParity` でコンパイル時検証。**片方を変更したら必ずもう片方も更新すること**
 - **JA/EN バイリンガル**: `web-next/lib/i18n.tsx` で全テキストを管理（`T` オブジェクト + `t()` / `tRich()` の React 要素ファクトリ）。各スクレイパーも `sub_ja` / `sub_en` や `note_ja` / `note_en` のペアで日英テキストを持つ。ガイドページ（Phase B–E）は当面 JA 固定
@@ -261,7 +265,7 @@ Build:     cd web-next && bun run build
 以下を全て確認してからコミットすること：
 
 1. `cd web-next && bun run build` が成功（※Antigravityサンドボックス環境では実行禁止。他環境やCIでは必須）
-2. `cd web-next && bun run test` が成功（実測 931 件合格を確認）
+2. `cd web-next && bun run test` が成功（実測 1040 件合格を確認）
 3. `cd web-next && bun run typecheck` が成功
 4. `cd web-next && bun run lint` が成功（既知の違反件数は CI または進捗ドキュメントを参照、新規違反がないこと）
 5. `cd scraper && uv run pytest` が成功

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # GEMINI.md
 
-Updated 2026-07-12
+Updated 2026-07-13
 
 GEMINI.md は Gemini CLI / Gemini Code Assist 向けの入り口。
 本リポジトリでは **CLAUDE.md が正本** とし、GEMINI.md はその委譲 pointer として機能する。
@@ -27,7 +27,7 @@ GEMINI.md は Gemini CLI / Gemini Code Assist 向けの入り口。
 ## 検証コマンド
 
 ```bash
-cd web-next && bun run test        # 931 pass（全 Green ✅）
+cd web-next && bun run test        # 1040 pass（全 Green ✅）
 cd web-next && bun run typecheck   # OK
 cd web-next && bun run build       # 全ルートが ○ (Static)
 cd web-next && bun run lint        # 0 件（全解消 ✅）

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,7 +27,7 @@ GEMINI.md は Gemini CLI / Gemini Code Assist 向けの入り口。
 ## 検証コマンド
 
 ```bash
-cd web-next && bun run test        # 1040 pass（全 Green ✅）
+cd web-next && bun run test        # 1046 pass（全 Green ✅）
 cd web-next && bun run typecheck   # OK
 cd web-next && bun run build       # 全ルートが ○ (Static)
 cd web-next && bun run lint        # 0 件（全解消 ✅）

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -14,10 +14,11 @@
   - `bun run typecheck` ✅
   - `bun run lint` ✅（本作業範囲では新規違反 0 件、既知の既存指摘は本件対象外）
 - **テストの実行状況**:
-  - **フロントエンド (`web-next/`)**: Vitest 実行で **1040 件すべて合格** (全 Green ✅)
+  - **フロントエンド (`web-next/`)**: Vitest 実行で **1046 件すべて合格** (全 Green ✅)
   - **バックエンド (`scraper/`)**: pytest 実行で **38 件すべて合格** (全 Green ✅)
 
 ## 最近の追加内容
+- **metadata 欠落 3 ページの SEO 修正**: F-1 のレジストリ初期値採取中に、`/code-review/coderabbit-guide`・`/code-review/sonar-qube`・`/codex/harness-engineering` の 3 ページだけ `export const metadata` を持たず、SEO タイトル・説明が出力されていないことが判明。根因は書き忘れではなく **Client Component 境界の設計差**で、前 2 ページはページ全体が `"use client"` のため Next.js の規約上 page.tsx から metadata を export できない状態だった（他 53 ページは Server Component）。TDD（Red→Green）で対応し、`"use client"` の 2 ページはルート単位の `layout.tsx`（Server Component）から metadata を供給（本体の大規模リファクタは行わない最小差分）、`codex/harness-engineering` は page.tsx へ直接追加。description は `lib/page-registry.ts` の summary と同一文言に統一。Vitest 契約テスト 6 件追加（合計 **1046 テスト合格**）。
 - **鮮度基盤（ページレジストリ + What's New）の導入 — plans/006 Phase 1（F-1 / F-2）**: `web-next/lib/page-registry.ts` を新設し、全 57 ルート（Home + 55 ガイド + What's New）のメタデータ（title / group / provider / topics / summary / addedAt / lastReviewed）を Zod 検証付きの SSoT として集約 🚀。初期値は全フィールドを機械採取（title/group は nav-links、summary は各 page.tsx の metadata.description、日付は git log）。TDD サイクル（Red/Green/Refactor）でコミット分割。派生実装として ① `components/site/PageFreshness.tsx` を `app/layout.tsx` に 1 箇所マウントし、55 個の page.tsx を編集せずに全ページへ「最終確認日 / 公開日」バッジを表示（SiteHeader と同じ `usePathname()` パターン。SSG プリレンダで静的 HTML に焼き込まれることをビルド出力で確認済み）、② `app/whats-new/page.tsx` を registry から静的生成（新着 = addedAt 降順 / 最近更新 = lastReviewed 降順、各上位 12 件）、③ `app/sitemap.ts` のハードコード ROUTES（24 件で実ルート 55 と乖離＝stale）を registry 駆動へ置換し欠落 31 ルートを解消、`lastmod` にビルド日時ではなく `lastReviewed` を出力。ナビはトップレベル 17 → 18 項目（末尾に What's New）。Vitest 契約テスト 44 件追加（合計 **1040 テスト合格**）。
 - **LLM評価・ベンチマーク & オブザーバビリティ ガイドの Next.js 移行**: ルートの `Llm-evaluation-observability-best-practices.html` を `web-next/app/llm-ops/evaluation-observability/page.tsx` に完全移行 🚀。TDD サイクル（Red/Green/Refactor）に沿ってステップバイステップでコミット。CSS Modules によるレイアウトスコープ化、外部リンクのセキュリティ対策（target/rel）、10個の Mermaid 図の中央寄せ、TOCスクロールハイライト追従（Intersection Observer）、およびモバイル開閉トグルを実装。ナビゲーションに新規カテゴリ「LLMOps -> Evaluation & Observability」を追加し、関連統合テストを 15 ドロップダウン対応に更新。元のHTML・MDファイルはアーカイブディレクトリに退避。Vitest 契約テスト 9 件追加（合計 931 テスト合格）。
 - **Google Stitch 実践ガイドの Next.js 移行**: ルートの `Google-stitch-guide.html` を `web-next/app/google/stitch-guide/page.tsx` に完全移行 🚀。TDD サイクル（Red/Green/Refactor）に沿ってステップバイステップでコミット。CSS Modules によるレイアウトスコープ化、外部リンクのセキュリティ対策（target/rel）、等幅フォント適用、7つの Mermaid 図の中央寄せ、TOCスクロールハイライト追従（Intersection Observer）、およびモバイル開閉トグルを実装。ナビゲーションの「Google -> Stitch Guide」に新規登録。元のHTML・MDファイルはアーカイブディレクトリに退避。Vitest 契約テスト 9 件追加（合計 922 テスト合格）。
@@ -185,7 +186,7 @@ Next.js 移行完了後のリポジトリ `LLM-Studies` にて、テストカバ
 Next.js 移行完了後のリポジトリ `LLM-Studies` の保守・改善作業を再開してください。
 
 - リポジトリ: LLM-Studies (Next.js 移行プロジェクトは dev/main へ完全マージ済み)
-  - 現在のステータス: docs/PROGRESS.md を参照。テストは Vitest (1040/1040 passed) / pytest (38/38 passed) で全 Green
+  - 現在のステータス: docs/PROGRESS.md を参照。テストは Vitest (1046/1046 passed) / pytest (38/38 passed) で全 Green
 - リポジトリ規約: CLAUDE.md (編集上の絶対ルール。※Antigravity環境ではビルドは実行禁止)
 
 作業方針：

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,7 +1,7 @@
 # プロジェクト進捗・ステータス (PROGRESS.md)
 
 > 本ファイルは Next.js 移行完了後の保守・改善フェーズにおける開発の進捗（特にテスト関連）および品質チェックのルールを記録する。
-> - 最終更新日: **Updated 2026-07-12**
+> - 最終更新日: **Updated 2026-07-13**
 > - 過去の移行進捗・旧ルール: [`docs/archive/MIGRATION_PROGRESS.md`](archive/MIGRATION_PROGRESS.md)
 > - 移行計画アーカイブ: [`docs/archive/NEXTJS_PHASE_A_F_PLAN.md`](archive/NEXTJS_PHASE_A_F_PLAN.md)
 
@@ -14,10 +14,11 @@
   - `bun run typecheck` ✅
   - `bun run lint` ✅（本作業範囲では新規違反 0 件、既知の既存指摘は本件対象外）
 - **テストの実行状況**:
-  - **フロントエンド (`web-next/`)**: Vitest 実行で **931 件すべて合格** (全 Green ✅)
+  - **フロントエンド (`web-next/`)**: Vitest 実行で **1040 件すべて合格** (全 Green ✅)
   - **バックエンド (`scraper/`)**: pytest 実行で **38 件すべて合格** (全 Green ✅)
 
 ## 最近の追加内容
+- **鮮度基盤（ページレジストリ + What's New）の導入 — plans/006 Phase 1（F-1 / F-2）**: `web-next/lib/page-registry.ts` を新設し、全 57 ルート（Home + 55 ガイド + What's New）のメタデータ（title / group / provider / topics / summary / addedAt / lastReviewed）を Zod 検証付きの SSoT として集約 🚀。初期値は全フィールドを機械採取（title/group は nav-links、summary は各 page.tsx の metadata.description、日付は git log）。TDD サイクル（Red/Green/Refactor）でコミット分割。派生実装として ① `components/site/PageFreshness.tsx` を `app/layout.tsx` に 1 箇所マウントし、55 個の page.tsx を編集せずに全ページへ「最終確認日 / 公開日」バッジを表示（SiteHeader と同じ `usePathname()` パターン。SSG プリレンダで静的 HTML に焼き込まれることをビルド出力で確認済み）、② `app/whats-new/page.tsx` を registry から静的生成（新着 = addedAt 降順 / 最近更新 = lastReviewed 降順、各上位 12 件）、③ `app/sitemap.ts` のハードコード ROUTES（24 件で実ルート 55 と乖離＝stale）を registry 駆動へ置換し欠落 31 ルートを解消、`lastmod` にビルド日時ではなく `lastReviewed` を出力。ナビはトップレベル 17 → 18 項目（末尾に What's New）。Vitest 契約テスト 44 件追加（合計 **1040 テスト合格**）。
 - **LLM評価・ベンチマーク & オブザーバビリティ ガイドの Next.js 移行**: ルートの `Llm-evaluation-observability-best-practices.html` を `web-next/app/llm-ops/evaluation-observability/page.tsx` に完全移行 🚀。TDD サイクル（Red/Green/Refactor）に沿ってステップバイステップでコミット。CSS Modules によるレイアウトスコープ化、外部リンクのセキュリティ対策（target/rel）、10個の Mermaid 図の中央寄せ、TOCスクロールハイライト追従（Intersection Observer）、およびモバイル開閉トグルを実装。ナビゲーションに新規カテゴリ「LLMOps -> Evaluation & Observability」を追加し、関連統合テストを 15 ドロップダウン対応に更新。元のHTML・MDファイルはアーカイブディレクトリに退避。Vitest 契約テスト 9 件追加（合計 931 テスト合格）。
 - **Google Stitch 実践ガイドの Next.js 移行**: ルートの `Google-stitch-guide.html` を `web-next/app/google/stitch-guide/page.tsx` に完全移行 🚀。TDD サイクル（Red/Green/Refactor）に沿ってステップバイステップでコミット。CSS Modules によるレイアウトスコープ化、外部リンクのセキュリティ対策（target/rel）、等幅フォント適用、7つの Mermaid 図の中央寄せ、TOCスクロールハイライト追従（Intersection Observer）、およびモバイル開閉トグルを実装。ナビゲーションの「Google -> Stitch Guide」に新規登録。元のHTML・MDファイルはアーカイブディレクトリに退避。Vitest 契約テスト 9 件追加（合計 922 テスト合格）。
 - **マルチモーダルAI実践ガイド：画像・音声生成のベストプラクティス 2026の Next.js 移行**: ルートの `Multimodal-image-audio-best-practices-2026.html` を `web-next/app/multimodal/image-audio-best-practices-2026/page.tsx` に完全移行 🚀。TDD サイクル（Red/Green/Refactor）に沿ってステップバイステップでコミット。CSS Modules によるレイアウトスコープ化、外部リンクのセキュリティ対策（target/rel）、18個の Mermaid 図の中央寄せ、TOCスクロールハイライト追従（Intersection Observer）、およびモバイル開閉トグルを実装。ナビゲーションの「Multimodal -> Image & Audio (2026)」に新規登録。元のHTML・MDファイルはアーカイブディレクトリに退避。Vitest 契約テスト 6 件追加（合計 911 テスト合格）。
@@ -184,7 +185,7 @@ Next.js 移行完了後のリポジトリ `LLM-Studies` にて、テストカバ
 Next.js 移行完了後のリポジトリ `LLM-Studies` の保守・改善作業を再開してください。
 
 - リポジトリ: LLM-Studies (Next.js 移行プロジェクトは dev/main へ完全マージ済み)
-  - 現在のステータス: docs/PROGRESS.md を参照。テストは Vitest (931/931 passed) / pytest (38/38 passed) で全 Green
+  - 現在のステータス: docs/PROGRESS.md を参照。テストは Vitest (1040/1040 passed) / pytest (38/38 passed) で全 Green
 - リポジトリ規約: CLAUDE.md (編集上の絶対ルール。※Antigravity環境ではビルドは実行禁止)
 
 作業方針：

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   base    = "web-next"
   command = "bun install && bun run build"
   publish = "out"
+  # base 配下に差分がない場合に Netlify がビルドを自動スキップする既定挙動を無効化する。
+  # 理由: base 外にある netlify.toml（リダイレクト定義）や pricing.json の変更が
+  #       反映されず、docs のみのコミットが "Deploy failed" として表示されるため。
+  # ignore は終了コード 0 でスキップ・非 0 でビルド実行。/bin/false は常に 1 を返す。
+  ignore  = "/bin/false"
 
 [build.environment]
   # Netlify でのランタイム指定

--- a/plans/001-current-state-analysis.md
+++ b/plans/001-current-state-analysis.md
@@ -1,0 +1,159 @@
+# Plan 001: web-next プラットフォーム現状分析（Current State Analysis）
+
+> **本ドキュメントの性格**: `.agent/skills/improve/SKILL.md`（direction バリアント）に基づく
+> **読み取り専用の分析ドキュメント**。実装手順は含まない。
+> [002（ギャップ分析）](002-category-gap-analysis.md) と [003（拡張ロードマップ）](003-platform-expansion-roadmap.md) の前提資料であり、
+> 将来の実装エージェントが本セッションのコンテキストなしで現状を再構築できることを目的とする。
+
+## Status
+
+- **Priority**: P1（002 / 003 の依存元）
+- **Effort**: —（分析のみ、実装なし）
+- **Risk**: —
+- **Depends on**: none
+- **Category**: direction（分析基盤）
+- **Planned at**: commit `3915136`, 2026-07-06
+
+## Why this matters
+
+本リポジトリは「AI モデルの時間別コスト計算機 + AI ツール導入ガイド群」として成長してきたが、
+ガイドページが 40 枚に達し、ナビゲーション構造（プロバイダー軸）と実際のコンテンツ（トピック横断）の間に
+歪みが生まれ始めている。「今後の AI 関連最新情報をキャッチアップできるプラットフォーム」へ拡張するには、
+まず現状の資産と構造的課題を正確に棚卸しする必要がある。
+
+## 1. プラットフォーム概要（データフロー）
+
+```text
+scraper/ (Python 3.12+, uv, Playwright)
+  └─ pricing.json 生成（3層フォールバック: scrape → 既存値 → ハードコード）
+       └─ update.sh が web-next/data/ と web-next/public/ へコピー
+            └─ web-next/ (Next.js 16 App Router, output: 'export', bun)
+                 └─ Netlify CDN（pure SSG、サーバーランタイムなし）
+```
+
+- ビルド時に `web-next/data/pricing.json` を static import し Zod で検証（`web-next/lib/pricing.ts`）
+- **SSG 制約**: サーバー API なし。動的機能はすべて「ビルド時生成 + クライアント JS」で実現する必要がある（003 の機能検討における最重要制約）
+
+## 2. web-next ディレクトリ構成（2026-07-06 時点）
+
+```text
+web-next/
+├── app/                 41 ルート（電卓ホーム 1 + ガイドページ 40）
+│   ├── page.tsx         コスト計算機ホーム（Server Component + Zod 検証）
+│   ├── layout.tsx       ルートレイアウト（SiteHeader / DisclaimerBanner マウント）
+│   ├── globals.css      Tailwind v4 + legacy デザイントークン
+│   └── <provider|topic>/<slug>/
+│       ├── page.tsx           各ガイド本体
+│       ├── page.module.css    CSS Modules（ページ単位スコープ）
+│       └── page.test.tsx      契約テスト（タイトル・セクション数・rel・metadata）
+├── components/
+│   ├── （電卓 UI 9 種: ApiTable / SubTable / Hero / HomePage / LanguageToggle 等）
+│   ├── docs/            ガイド共通: CodeCopyButton.tsx / MermaidDiagram.tsx
+│   └── site/            共通: SiteHeader / SiteHeaderClient / DisclaimerBanner / nav-links.ts
+├── lib/
+│   ├── cost.ts          純粋関数（calcApiCost / calcSubCost / fmtUSD / fmtJPY）
+│   ├── pricing.ts       Zod スキーマ + Pydantic とのコンパイル時パリティ検証
+│   ├── i18n.tsx         JA/EN バイリンガル（電卓のみ。ガイドは JA 固定）
+│   ├── useTocObserver.ts  TOC スクロール追従（Intersection Observer）
+│   ├── metadata.ts / fonts.ts / site-url.ts
+│   └── index.ts
+├── types/pricing.ts     Pydantic models.py の手動ミラー
+├── data/ + public/      pricing.json（2 箇所配信）
+└── tests/               vitest（803 件全 Green — 2026-07-06 実測。docs/PROGRESS.md 記載は 801）
+```
+
+### app/ ルート内訳（41 ルート）
+
+| 第1セグメント | ルート数 | 内容 |
+|---|---|---|
+| `/`（ルート） | 1 | コスト計算機ホーム |
+| `claude/` | 11 | skill, agent, skill-guide ×2, cowork-guide, harness-engineering, managed-agents, self-hosted-sandboxes, code-slash-commands, fable-5-best-practices, skills-sh |
+| `google/` | 9 | skill, agent, skill-guide ×2, sandbox-best-practices, antigravity-guide, antigravity-slash-commands-guide, harness-engineering, agent-harness-engineering |
+| `codex/` | 4 | skill, agent, openai-codex-guide, harness-engineering |
+| `copilot/` | 4 | skill, agent, markdown-file-guide, github-copilot |
+| `agent/` | 4 | hermes-agent-advanced-guide, openclaw-advanced-agent-security-guide, loop-engineering, skills |
+| `code-review/` | 4 | tool-pricing, coderabbit-guide, copilot-code-review, sonar-qube |
+| `cursor/` | 2 | complete-guide, complete-guide-intermediate |
+| `vercel/` | 1 | sandbox |
+| `git-worktree` | 1 | git-worktree |
+
+## 3. ナビゲーションカテゴリのインベントリ
+
+`web-next/components/site/nav-links.ts:33-113` で定義。Zod スキーマ（同 :7-27）で
+href の安全性（`/` 始まり・`javascript:` 拒否）をコンパイル時ではなく実行時に検証する構造。
+
+| ナビカテゴリ | 型 | リンク数 | 軸の種類 |
+|---|---|---|---|
+| Home | leaf | 1 | 機能（電卓） |
+| Claude | dropdown | 10 | プロバイダー |
+| Google | dropdown | 9 | プロバイダー |
+| Codex | dropdown | 4 | プロバイダー |
+| Copilot | dropdown | 4 | プロバイダー |
+| Code Review | dropdown | 4 | **トピック** |
+| Agent | dropdown | 5 | **トピック** |
+| Sandbox | dropdown | 1 | **トピック** |
+| IDE | dropdown | 2 | **トピック** |
+| Git Worktree | leaf | 1 | **トピック** |
+
+- 全 41 ルートはナビから到達可能（孤立ページなし。2026-07-06 に nav-links.ts と app/ の突合で確認）
+- プロバイダー軸 4 カテゴリ（27 リンク）とトピック軸 5 カテゴリ（13 リンク）が**同一階層に混在**
+
+## 4. 共有インフラ資産（拡張時に再利用すべきもの）
+
+| 資産 | 場所 | 役割 |
+|---|---|---|
+| nav-links + Zod | `components/site/nav-links.ts` | ナビ SSoT。カテゴリ追加はここ 1 箇所 |
+| 契約テストパターン | 各 `page.test.tsx` | タイトル・セクション数・外部リンク rel・metadata の 4 点検証。新ページ追加時の雛形 |
+| SiteHeader / DisclaimerBanner | `components/site/` | 全ページ共通シェル（layout.tsx でマウント） |
+| CodeCopyButton | `components/docs/CodeCopyButton.tsx` | コピー付きコードブロック |
+| MermaidDiagram | `components/docs/MermaidDiagram.tsx` | `next/dynamic({ ssr: false })` 遅延ロード |
+| useTocObserver | `lib/useTocObserver.ts` | TOC スクロールハイライト追従 |
+| i18n 基盤 | `lib/i18n.tsx` | T オブジェクト + `t()` / `tRich()`。現状は電卓のみ利用 |
+| pricing パイプライン | `scraper/` + `update.sh` | 価格データの自動収集・3層フォールバック・`scrape_status` による出自追跡 |
+| monthly-update スキル | `.claude/skills/monthly-update/` | 全ページの価格・バージョン・リンクの月次同期プロセス（2026-06 実績: 14/35 完了の運用実績あり） |
+| nextjs-page-migration スキル | `.claude/skills/nextjs-page-migration/` | 新規ガイドページ追加の TDD 手順 |
+
+## 5. 強み
+
+1. **ページ追加コストが低い**: 契約テスト + CSS Modules + nav-links 追加の定型パターンが確立済み（直近の Loop Engineering / skills.sh 移行で実証。`docs/PROGRESS.md` 参照）
+2. **品質ゲートが機械化済み**: 803 テスト Green（2026-07-06 実測） + typecheck + Biome + SonarQube CI
+3. **価格データの自動更新基盤**: scraper + 3層フォールバックは「情報鮮度の自動維持」という
+   プラットフォーム化の核になる仕組みを既に持っている（現状は価格のみ）
+4. **XSS 対策の一貫性**: 生 HTML 挿入 API 不使用を静的検査テストで CI 担保
+
+## 6. 構造的課題（evidence 付き）
+
+### [STATE-01] プロバイダー軸とトピック軸の混在によるカテゴリ歪み
+
+- **Evidence**: `components/site/nav-links.ts:98` — 「skills.sh Guide」は Agent（トピック）配下だが href は `/claude/skills-sh`（プロバイダー URL）。逆に `components/site/nav-links.ts:43,60-61` と `codex/harness-engineering` — 「Harness Engineering」という同一トピックが 3 プロバイダーのドロップダウンに分散
+- **Impact**: 「エージェント設計を学びたい」読者はどのドロップダウンを開くべきか判断できない。トピックが増えるたびに歪みが拡大する
+- **Confidence**: HIGH（コード確認済み）
+
+### [STATE-02] コンテンツの鮮度メタデータが表示されない
+
+- **Evidence**: 各 `page.tsx` に「最終確認日」の構造化フィールドがない。鮮度管理は `.claude/skills/monthly-update/` の運用プロセスと `docs/PROGRESS.md` の記述に依存し、**読者からは見えない**
+- **Impact**: 「最新情報キャッチアップ・プラットフォーム」を標榜する上で、読者が情報の鮮度を判定できないのは致命的な信頼性欠陥になる
+- **Confidence**: HIGH
+
+### [STATE-03] 横断ナビゲーション手段の不在
+
+- **Evidence**: 40 ガイドに対し検索・タグ・関連ページリンクが存在しない（`components/site/` にはヘッダーとバナーのみ）。ナビはドロップダウン 2 階層が唯一の導線
+- **Impact**: ページ数が 50〜60 枚に達するとドロップダウンが破綻する（Claude 配下は既に 10 リンク）
+- **Confidence**: HIGH
+
+### [STATE-04] i18n 資産がガイドで未活用
+
+- **Evidence**: `lib/i18n.tsx` は電卓 UI のみで使用。ガイド 40 枚は JA 固定（`CLAUDE.md` の設計判断として記録済み — 課題ではなく決定事項だが、EN 展開時の前提として記録）
+- **Impact**: 英語圏リーチなし。ただし EN 展開はコンテンツ翻訳コストが支配的で、インフラは既存
+- **Confidence**: HIGH（ADR 相当の決定として CLAUDE.md に記録あり — 003 では「選択肢」として扱う）
+
+### [STATE-05] 更新履歴が開発者向けドキュメントにしか存在しない
+
+- **Evidence**: 新ページ・機能の追加履歴は `docs/PROGRESS.md`（開発者向け・リポジトリ内）のみ。サイト上に What's New に相当するページがない
+- **Impact**: リピーター読者が「前回訪問以降に何が増えたか」を知る手段がない
+- **Confidence**: HIGH
+
+## 7. 次のドキュメントへの接続
+
+- **[002 ギャップ分析](002-category-gap-analysis.md)**: 上記インベントリ（§3）を基準に、AI 駆動開発の情報収集として不足しているカテゴリを特定する
+- **[003 拡張ロードマップ](003-platform-expansion-roadmap.md)**: STATE-01〜05 の構造課題への対処と新カテゴリ受け入れの順序を設計する

--- a/plans/002-category-gap-analysis.md
+++ b/plans/002-category-gap-analysis.md
@@ -1,0 +1,123 @@
+# Plan 002: AI 情報収集カテゴリのギャップ分析（Category Gap Analysis）
+
+> **本ドキュメントの性格**: [001（現状分析）](001-current-state-analysis.md) のインベントリを基準に、
+> 「AI に関する情報収集・AI 駆動開発のための情報プラットフォーム」として不足しているカテゴリを、
+> リポジトリ内の evidence と 2026 年時点の外部トレンドの両面から特定する分析ドキュメント。実装手順は含まない。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: —（分析のみ）
+- **Risk**: —
+- **Depends on**: [001-current-state-analysis.md](001-current-state-analysis.md)
+- **Category**: direction
+- **Planned at**: commit `3915136`, 2026-07-06
+
+## Why this matters
+
+現行 40 ガイドは「コーディングエージェントの使い方」（プロバイダー別 Skill / Agent / Harness）に
+強く偏っている。AI 駆動開発の実務は 2026 年時点で「エージェントへの移行・MCP 標準化・
+コンテキストエンジニアリング・評価と観測」へ広がっており、このギャップを放置すると
+プラットフォームの網羅性が読者の実務ニーズから乖離する。
+
+## 1. 現状カバレッジマップ
+
+001 §3 のインベントリを情報カテゴリとして再集計したもの:
+
+| 情報カテゴリ | カバー状況 | 該当ページ |
+|---|---|---|
+| コスト計算・料金比較 | ✅ 厚い | 電卓ホーム, `/code-review/tool-pricing`（自動更新パイプラインあり） |
+| コーディングエージェントの使い方 | ✅ 最も厚い | Claude/Google/Codex/Copilot の skill・agent・guide 群（27 ページ） |
+| AI コードレビュー | ✅ あり | code-review 4 ページ |
+| エージェント設計・運用 | ✅ あり | agent 4 ページ + harness-engineering 4 ページ（プロバイダー分散） |
+| サンドボックス・実行環境 | ✅ あり | vercel/sandbox, claude/self-hosted-sandboxes, google/sandbox-best-practices |
+| IDE | △ 薄い | cursor 2 ページのみ |
+| Git ワークフロー | △ 単発 | git-worktree 1 ページ |
+
+## 2. 外部トレンド検証（2026-07 時点、WebSearch 実施済み）
+
+ギャップ候補の裏付けとして確認した 2026 年時点の外部シグナル:
+
+- **エージェントへの移行**: 開発者の役割が「AI オーケストレーター」へ移行。コパイロット型からエージェント型が標準に
+- **MCP の標準化**: MCP サーバーは 2025-08〜2026-02 の 6 ヶ月で 232% 増。エージェントスタックの共通言語として定着
+- **コンテキストエンジニアリング**: エージェント精度向上の中核規律として確立
+- **評価と観測**: エージェントのオブザーバビリティ導入 89% に対し evals 導入は 52% — 実務ギャップが大きく情報需要が高い
+- **品質と信頼**: 開発者の 96% が AI 出力を無条件には信頼せず、品質が本番導入の最大障壁（32%）
+
+参照元（確認日 2026-07-06）:
+[The Pragmatic Engineer](https://newsletter.pragmaticengineer.com/p/the-impact-of-ai-on-software-engineers-2026) /
+[Anthropic 2026 Agentic Coding Trends Report](https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf) /
+[The New Stack: MCP roadmap 2026](https://thenewstack.io/model-context-protocol-roadmap-2026/) /
+[LangChain: State of Agent Engineering](https://www.langchain.com/state-of-agent-engineering) /
+[Anthropic: Demystifying evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+
+## 3. ギャップ候補（優先度順）
+
+各候補の repo 内言及数は 2026-07-06 に `grep -rl <keyword> --include='page.tsx' web-next/app` で実測。
+
+### [GAP-01] MCP（Model Context Protocol）専用カテゴリ — 優先度 High
+
+- **Evidence（repo）**: 40 ガイド中 **26 ページが MCP に言及**しているが、MCP を主題とするページ・カテゴリは 0。断片的な言及が最多のトピック
+- **Evidence（外部）**: §2 — 6 ヶ月で 232% 増、エージェントスタックの標準
+- **既存カテゴリとの関係**: Agent カテゴリの下位ではなく独立カテゴリが妥当（サーバー構築・セキュリティ・クライアント設定と切り口が多い）
+- **Confidence**: HIGH ／ **想定ページ数**: 2〜3（入門・サーバー構築・セキュリティ）
+
+### [GAP-02] コンテキストエンジニアリング / プロンプト設計 — 優先度 High
+
+- **Evidence（repo）**: 「コンテキストエンジニアリング」への言及 **0 ページ**。一方で harness-engineering 4 ページ・skill-guide 群という隣接資産が既に厚く、「エージェントに何を読ませるか」の体系的解説だけが欠けている
+- **Evidence（外部）**: §2 — 2026 年の中核規律として確立
+- **既存カテゴリとの関係**: harness-engineering 群（現状 3 プロバイダーに分散 — 001 STATE-01）をトピック軸で統合する受け皿になり得る
+- **Confidence**: HIGH ／ **想定ページ数**: 2（原則編・実践編）
+
+### [GAP-03] AI セキュリティ — 優先度 High
+
+- **Evidence（repo）**: プロンプトインジェクション言及 6 ページ、`/agent/openclaw-advanced-agent-security-guide` という深掘りページが既に 1 枚存在 — 「1 ページだけある」のはカテゴリ化直前の典型シグナル
+- **既存カテゴリとの関係**: openclaw ガイド + sandbox 3 ページを「AI Security」カテゴリへ横断整理し、一般論（インジェクション分類・権限設計・サンドボックス境界）を追加
+- **Confidence**: HIGH ／ **想定ページ数**: 1〜2 新規 + 既存 1〜4 の再配置
+
+### [GAP-04] モデルリリース・アップデートトラッキング — 優先度 High
+
+- **Evidence（repo）**: `scraper/` + `update.sh` + monthly-update スキルという**鮮度維持の仕組みが既に存在**するが、対象が価格のみ。001 STATE-02/05 のとおり読者向けの鮮度・更新情報の表示がない。「adjacent possible」（既存アーキテクチャが安価にする拡張）の典型
+- **既存カテゴリとの関係**: 新規ページ群ではなく**プラットフォーム機能**（What's New / モデル一覧の鮮度表示）として 003 で扱う
+- **Confidence**: HIGH ／ **想定規模**: 003 の Phase 1 参照
+
+### [GAP-05] 評価・ベンチマーク / オブザーバビリティ — 優先度 Mid
+
+- **Evidence（repo）**: ベンチマーク言及 7 ページ、オブザーバビリティ言及 1 ページ。主題ページ 0
+- **Evidence（外部）**: §2 — evals 導入 52% vs 観測 89% のギャップ = 学習需要
+- **Confidence**: MED（外部需要は明確だが、本サイト読者層との適合は要観察）／ **想定ページ数**: 1〜2
+
+### [GAP-06] AI CI/CD 自動化 — 優先度 Mid
+
+- **Evidence（repo）**: このリポジトリ自体が SonarQube CI・auto-fix ワークフロー・Git フックを運用しており（`.github/workflows/`、`.githooks/`）、「自分で実践しているのに解説がない」状態。code-review カテゴリの自然な拡張
+- **Confidence**: MED ／ **想定ページ数**: 1〜2（AI × GitHub Actions、自動修正パイプライン）
+
+### [GAP-07] ローカル LLM / セルフホスティング — 優先度 Low〜Mid
+
+- **Evidence（repo）**: Ollama 言及 **0 ページ**。`claude/self-hosted-sandboxes` が隣接するが、モデル自体のセルフホストは完全に空白
+- **Confidence**: LOW（本サイトの主軸＝クラウドエージェント＋コスト計算との整合を要検討。コスト比較の切り口なら電卓と相性が良い）／ **想定ページ数**: 1
+
+### [GAP-08] RAG・埋め込み — 優先度 Low
+
+- **Evidence（repo）**: 言及 3 ページのみ。コーディングエージェント文脈では MCP・コンテキストエンジニアリング（GAP-01/02）に吸収されつつあるのが 2026 年の実態
+- **Confidence**: LOW ／ **判断**: 独立カテゴリにせず、GAP-02 の中の 1 セクションで扱うことを推奨
+
+### [GAP-09] マルチモーダル / 画像・音声生成 — 採否判断: スコープ外を推奨
+
+- **Evidence（repo）**: 言及ほぼなし。本サイトの一貫した主題は「AI **駆動開発**」であり、生成メディアはペルソナが異なる
+- **判断**: 追加しない（rejected として記録）。追加するとナビとメンテナンス（monthly-update）の負担が読者価値に見合わない
+
+## 4. 推奨カテゴリ体系（003 への入力）
+
+ギャップ分析の結論として、トピック軸カテゴリを次の形で拡張することを推奨:
+
+```text
+既存トピック軸:  Code Review / Agent / Sandbox / IDE / Git Worktree
+追加（High）:    MCP / Context Engineering / AI Security
+機能として追加:  Updates（What's New + 鮮度表示 — GAP-04）
+追加（Mid、需要確認後）: Evals & Observability / AI CI/CD
+不採用:          マルチモーダル（GAP-09）、RAG 単独カテゴリ（GAP-08）
+```
+
+プロバイダー軸（Claude/Google/Codex/Copilot）は入口として維持しつつ、新規コンテンツは
+原則トピック軸に配置する。この二軸構成の詳細設計は [003](003-platform-expansion-roadmap.md) で行う。

--- a/plans/003-platform-expansion-roadmap.md
+++ b/plans/003-platform-expansion-roadmap.md
@@ -1,0 +1,115 @@
+# Plan 003: AI 最新情報キャッチアップ・プラットフォーム拡張ロードマップ
+
+> **本ドキュメントの性格**: [001（現状分析）](001-current-state-analysis.md) の構造課題 STATE-01〜05 と
+> [002（ギャップ分析）](002-category-gap-analysis.md) の GAP-01〜09 を入力に、
+> プラットフォームの目指す構成・実施順序・トレードオフを定義する方向性ドキュメント。
+> **本ドキュメント自体は実装しない**。各項目は着手時に improve スキルの `plan <description>` で
+> 個別の実行プラン（`plans/NNN-*.md`）へ分割する。
+
+## Status
+
+- **Priority**: P1（方向性の合意が全プランの前提）
+- **Effort**: 項目別に記載（direction のため概算 — 精緻化は個別プラン時）
+- **Risk**: 項目別に記載
+- **Depends on**: [001](001-current-state-analysis.md), [002](002-category-gap-analysis.md)
+- **Category**: direction
+- **Planned at**: commit `3915136`, 2026-07-06
+
+## 1. プラットフォームの目標像
+
+> 「AI 駆動開発の実務者が、**信頼できる鮮度表示付き**で、プロバイダー横断のトピック軸から
+> 最新のツール・プロトコル・手法をキャッチアップできる日本語プラットフォーム」
+
+現状との差分は 3 点に集約される:
+
+1. **鮮度が見えない**（STATE-02/05）→ 情報プラットフォームとしての信頼性の根幹
+2. **トピック軸が弱い**（STATE-01/03、GAP-01〜03）→ 実務者は「Claude のページ」ではなく「MCP のページ」を探す
+3. **横断導線がない**（STATE-03）→ 40 ページ超のスケールでドロップダウンが限界
+
+## 2. 情報アーキテクチャ（IA）の再編方針
+
+### 選択肢の比較
+
+| 案 | 内容 | 利点 | 欠点 |
+|---|---|---|---|
+| A: 現状維持 | プロバイダー軸のまま追加 | 作業ゼロ | STATE-01 の歪みが拡大し続ける |
+| B: 完全トピック軸再編 | URL ごと `/topics/mcp/` 等へ移動 | IA が一貫 | 全 URL 変更 + リダイレクト必須。**netlify.toml 変更は AI 変更ルールで原則禁止**（要ユーザー承認）。SEO リスク |
+| **C: ハイブリッド（推奨）** | **URL は不変。ナビとメタデータだけ二軸化** | リダイレクト不要・低リスク・段階導入可 | URL とトピックの対応は registry（後述）が担保する間接構造になる |
+
+**推奨は C**。根拠: 既存 41 URL は外部から参照されており、`output: 'export'` + Netlify という
+構成上リダイレクトは netlify.toml でしか実現できず、これは AI 変更ルール（CLAUDE.md「環境変数・
+Netlify 設定の変更」禁止）に抵触するため、URL 移動はユーザーの明示判断が必要な HIGH リスク作業。
+一方ナビの二軸化は `web-next/components/site/nav-links.ts` の編集のみで完結する。
+
+### C 案の骨子: ページレジストリ（メタデータ SSoT）
+
+全機能拡張の共通基盤として、各ページの属性を 1 箇所に集約する:
+
+```text
+web-next/lib/page-registry.ts（新設・概念形）
+  { slug, title, provider?, topics[], addedAt, lastReviewed, summary }
+```
+
+- `nav-links.ts`（Zod 検証パターン）の発展形として同じ流儀で実装し、ナビ・What's New・
+  鮮度表示・タグ・RSS がすべてこの registry から導出される構造にする
+- 既存の契約テストパターンで「全 page.tsx が registry に登録されていること」を機械検証できる
+
+## 3. 機能拡張候補（impact / effort / risk）
+
+| ID | 機能 | 対応課題 | Impact | Effort | Risk |
+|---|---|---|---|---|---|
+| F-1 | ページレジストリ + 最終確認日表示 | STATE-02, GAP-04 | **High**（信頼性の根幹） | M（40 ページへの初期値投入が主コスト） | LOW（表示追加のみ、URL 不変） |
+| F-2 | What's New ページ（更新情報フィード） | STATE-05, GAP-04 | **High**（リピーター価値） | S〜M（registry から静的生成） | LOW |
+| F-3 | RSS フィード / sitemap 強化 | STATE-05 | Mid（キャッチアップ動線） | S（ビルド時生成。既存 sitemap の有無は着手時に要確認） | LOW |
+| F-4 | ナビ二軸化（トピックドロップダウン追加） | STATE-01/03 | High | S（nav-links.ts + テスト更新のみ） | LOW〜MED（既存ナビテストの期待値更新が必要） |
+| F-5 | タグ・横断検索（ビルド時インデックス） | STATE-03 | Mid〜High（50 ページ超で必須化） | L | MED（検索ライブラリ追加は「外部依存の追加」で要ユーザー確認。自前実装なら回避可） |
+| F-6 | EN 展開（ガイドの i18n 化） | STATE-04 | Mid（リーチ拡大） | XL（翻訳コストが支配的。`lib/i18n.tsx` 基盤は既存） | MED（JA 固定は CLAUDE.md 記載の設計判断 — 変更はユーザー判断事項） |
+
+## 4. コンテンツ拡張候補（002 の結論の実施形）
+
+| ID | カテゴリ | 出典 | 新規ページ | ナビ配置（C 案） |
+|---|---|---|---|---|
+| C-1 | MCP | GAP-01 | 2〜3（入門 / サーバー構築 / セキュリティ） | 新トピック「MCP」 |
+| C-2 | Context Engineering | GAP-02 | 2（原則 / 実践） | 新トピック（既存 harness-engineering 4 ページを registry の topics で同カテゴリに紐付け） |
+| C-3 | AI Security | GAP-03 | 1〜2 + 既存 openclaw / sandbox 群の紐付け | 新トピック「AI Security」 |
+| C-4 | Evals & Observability | GAP-05 | 1〜2 | Agent 配下 → 需要次第で独立 |
+| C-5 | AI CI/CD | GAP-06 | 1〜2 | Code Review 配下 → 需要次第で独立 |
+
+新規ページの実装は既存の確立パターン（`.claude/skills/nextjs-page-migration/` の TDD 手順、
+契約テスト、CSS Modules、`components/docs/` の共有コンポーネント）に完全準拠する。
+
+## 5. フェーズ分けと依存関係
+
+```text
+Phase 1: 情報鮮度基盤（F-1 → F-2 → F-3）
+  └─ F-1 の registry が F-2/F-3/F-4/F-5 すべての前提。最優先
+Phase 2: カテゴリ拡張（C-1 MCP → C-2 Context Eng → C-3 AI Security）＋ F-4 ナビ二軸化
+  └─ F-4 は C-1 の 1 ページ目と同時に入れると新カテゴリの受け皿が最初から存在する
+Phase 3: 横断機能（F-5 タグ・検索）
+  └─ registry（F-1）と一定のページ数（Phase 2 完了後）が揃ってから
+Phase 4（任意・ユーザー判断待ち）: C-4 / C-5 の需要確認後追加、F-6 EN 展開
+```
+
+- **依存の要**: F-1（registry）。これを飛ばして F-2 以降を作ると、ページ属性が
+  ナビ・フィード・タグに三重複製され STATE-01 と同型の歪みを再生産する
+- **monthly-update スキルとの接続**: F-1 導入後は monthly-update の確認結果を
+  `lastReviewed` 更新として registry に書き戻すことで、運用プロセスと表示が一体化する
+
+## 6. 個別プラン化の指針（実装着手時）
+
+1. 各項目は improve スキルの `plan <description>` で `plans/NNN-*.md` として起票する
+   （例: `plan F-1 ページレジストリと最終確認日表示の導入`）。direction 項目のため、
+   F-5 と F-6 は build プランではなく **design/spike プラン**（方式調査 + プロトタイプ + 未解決論点の列挙）から始める
+2. 個別プランは `.agent/skills/improve/references/plan-template.md` に準拠し、
+   TDD ルール（`.claude/rules/tdd-mandatory-cycle.md`: Red → Green → Refactor → Docs Sync のコミット分割）を Steps に織り込む
+3. **ユーザー確認が必須の項目**（AI 変更ルール抵触）: URL 移動・リダイレクト（netlify.toml）、
+   検索ライブラリ等の外部依存追加、EN 展開（既存設計判断の変更）
+4. **STOP 条件の共通形**: nav-links.ts / 契約テストの期待値が本ドキュメント作成時
+   （commit `3915136`）から乖離していた場合は、001 の再棚卸しから始める
+
+## 7. 本ロードマップで扱わないこと（rejected）
+
+- **マルチモーダル / 画像・音声生成カテゴリ**: GAP-09 のとおり読者ペルソナが異なるため不採用
+- **RAG 独立カテゴリ**: GAP-08 のとおり C-2（Context Engineering）内の 1 セクションへ吸収
+- **URL 全面再編（B 案）**: リダイレクト運用コストと AI 変更ルール抵触のため、C 案で目的を達成できる限り実施しない
+- **CMS / DB の導入**: pure SSG + Git 管理という現行アーキテクチャの強み（`docs/` 参照）を放棄する理由がない

--- a/plans/004-reconciliation-2026-07.md
+++ b/plans/004-reconciliation-2026-07.md
@@ -86,7 +86,7 @@ STATE-01 と同型の歪みを再生産する」がそのまま現実化した�
 ### [STATE-06] ナビトップレベルの過密（16 項目）
 
 - **Evidence**: `nav-links.ts:33-169` — Home + プロバイダー 4 + トピック 10 + Git Worktree の 16 項目。
-  うち 1 リンクのみのカテゴリが 3 つ（Sandbox / CI/CD / RAG）、2 リンクが 5 つ（MCP / Local LLM / IDE / Security / Multimodal）
+  うち 1 リンクのみのカテゴリが 4 つ（Sandbox / CI/CD / RAG / LLMOps）、2 リンクが 5 つ（MCP / Local LLM / IDE / Security / Multimodal）
 - **Impact**: 001 STATE-03 の「ドロップダウン破綻」がトップレベル自体で発生。モバイル開閉トグルの一覧性も限界
 - **Confidence**: HIGH（実測）
 
@@ -102,7 +102,8 @@ STATE-01 と同型の歪みを再生産する」がそのまま現実化した�
 ### [STATE-08] 鮮度表示の欠如が 56 ページ規模に拡大（STATE-02 の深刻化）
 
 - **Evidence**: 各 page.tsx に最終確認日フィールドなし（変わらず）。monthly-update スキルの 2026-06 実績は
-  14/35 完了で停止しており、残 21 ページ + 新規 21 ページの鮮度が読者からもメンテナーからも見えない
+  14/35 完了で停止しており、残 21 ページ + 新規 15 ページ（現在 56 ルート − 001 時点 41 ルート）の
+  鮮度が読者からもメンテナーからも見えない
 - **Confidence**: HIGH
 
 ## 6. 001〜003 の処遇

--- a/plans/004-reconciliation-2026-07.md
+++ b/plans/004-reconciliation-2026-07.md
@@ -1,0 +1,117 @@
+# Plan 004: 照合ドキュメント — 001〜003 と現状の突合（Reconciliation 2026-07）
+
+> **本ドキュメントの性格**: `.agent/skills/improve/SKILL.md` の `reconcile` バリアントに基づき、
+> [001（現状分析）](001-current-state-analysis.md) / [002（ギャップ分析）](002-category-gap-analysis.md) /
+> [003（拡張ロードマップ）](003-platform-expansion-roadmap.md)（いずれも commit `3915136`, 2026-07-06 作成）と
+> 現状との差分を検証・記録する。**実装手順は含まない**。
+> [005（ギャップ分析 v2）](005-category-gap-analysis-v2.md) と [006（ロードマップ v2）](006-platform-roadmap-v2.md) の前提資料。
+
+## Status
+
+- **Priority**: P1（005 / 006 の依存元）
+- **Effort**: —（照合のみ、実装なし）
+- **Risk**: —
+- **Depends on**: [001](001-current-state-analysis.md), [002](002-category-gap-analysis.md), [003](003-platform-expansion-roadmap.md)
+- **Category**: reconcile
+- **Planned at**: commit `45940fd`, 2026-07-12
+
+## Why this matters
+
+001〜003 の作成（`3915136`）から本照合（`45940fd`）まで **154 コミット**が積まれ、
+ルート数は 41 → **56** に増加した。003 §6 の STOP 条件
+「nav-links.ts / 契約テストの期待値が commit `3915136` から乖離していた場合は 001 の再棚卸しから始める」
+に該当するため、個別プラン起票の前に本照合で差分を確定し、001〜003 を STALE として保存する。
+
+## 1. 実測サマリ（2026-07-12, commit `45940fd`）
+
+| 指標 | 001〜003 作成時 | 現在 | 検証方法 |
+|---|---|---|---|
+| app/ ルート数 | 41 | **56** | `find web-next/app -name page.tsx \| wc -l` |
+| ナビトップレベル項目 | 10 | **16** | `web-next/components/site/nav-links.ts:33-169` |
+| vitest テスト数 | 803 | **931** | `AGENTS.md` / `CLAUDE.md` 記載（commit `8a5fc61` で同期済み） |
+| sitemap / robots | なし | **あり** | `web-next/app/sitemap.ts`, `web-next/app/robots.ts` |
+| ページレジストリ | なし | **なし（変わらず）** | `web-next/lib/page-registry.ts` 不在 |
+
+## 2. コンテンツ拡張の照合（002 / 003 の C 項目）
+
+以下は全て 2026-07-12 に `web-next/app/<route>/page.test.tsx` の存在を実測確認済み。
+全 12 新規ページが契約テスト付きで TDD サイクル（test → feat → refactor → docs のコミット分割）により追加されている
+（`git log --oneline 3915136..45940fd` で確認）。
+
+| 計画項目 | 計画時の判断 | 現状 | 実装ルート |
+|---|---|---|---|
+| C-1 MCP（GAP-01, High） | 2〜3 ページ新設 | ✅ **DONE** | `/mcp/mcp-best-practices`, `/mcp/mcp-best-practices-intermediate` + ナビ「MCP」新設 |
+| C-2 Context Engineering（GAP-02, High） | 2 ページ + harness 統合 | ⚠️ **部分達成** | `/agent/context-engineering-best-practices` 1 ページのみ。ナビは Agent 配下。harness-engineering 4 ページのトピック統合は未実施 |
+| C-3 AI Security（GAP-03, High） | 1〜2 新規 + 既存再配置 | ⚠️ **部分達成** | `/security/ai-security-best-practices`（+中級）+ ナビ「Security」新設。**既存 openclaw / sandbox 群の紐付け・再配置は未実施** |
+| C-4 Evals & Observability（GAP-05, Mid） | Agent 配下 → 需要次第 | ✅ **DONE（独立カテゴリで実装）** | `/llm-ops/evaluation-observability` + ナビ「LLMOps」新設 |
+| C-5 AI CI/CD（GAP-06, Mid） | Code Review 配下 → 需要次第 | ✅ **DONE（独立カテゴリで実装）** | `/ci-cd/ai-cicd-automation-best-practices` + ナビ「CI/CD」新設 |
+| GAP-07 Local LLM（Low〜Mid） | 1 ページ | ✅ **DONE（計画超過）** | `/local-llm/self-hosting`, `/local-llm/best-practices` + ナビ「Local LLM」新設 |
+
+その他の追加（001〜003 に計画がなかったもの）: `/google/notebook-lm`, `/google/adk-best-practices`,
+`/google/stitch-guide`（プロバイダー軸の深化。Google ドロップダウンは 12 リンクに増加）。
+
+## 3. 決定変更の記録（rejected → 採用）
+
+002 / 003 で「不採用」と記録した 2 カテゴリが、その後のユーザー判断により**採用・実装済み**となった。
+README の「検討済み・不採用」リストから削除する（本セクションが削除根拠）。
+
+### [REC-01] GAP-08 RAG: 不採用（C-2 内セクション吸収）→ 独立カテゴリとして採用
+
+- **Evidence**: `/rag/embeddings-best-practices`（`page.test.tsx` あり）、ナビ「RAG」新設（`nav-links.ts:147-150`）
+- コミット系列 `8672e9b`（test）→ `50d3137`（feat）→ `12e91fa`（refactor）→ `a8db213`（docs）
+
+### [REC-02] GAP-09 マルチモーダル: スコープ外 → 独立カテゴリとして採用（2 ページ）
+
+- **Evidence**: `/multimodal/generation-best-practices`, `/multimodal/image-audio-best-practices-2026`、ナビ「Multimodal」新設（`nav-links.ts:151-163`）
+- 002 の不採用根拠は「読者ペルソナ（AI 駆動開発者）と不一致」だったが、採用済みの現状を優先事実とする。
+  005 ではペルソナ定義自体を「AI 駆動開発者」から「AI 活用実務者（開発中心）」へ広げて再解釈する
+
+## 4. 機能拡張（F 項目）の照合 — Phase 1 が未着手のままコンテンツが先行
+
+| ID | 機能 | 計画時 | 現状 | 備考 |
+|---|---|---|---|---|
+| F-1 | ページレジストリ + 最終確認日表示 | Phase 1 最優先 | ❌ **未着手** | `web-next/lib/page-registry.ts` 不在。対象が 40 → 56 ページに増え初期値投入コストは M → **L** へ上方修正 |
+| F-2 | What's New ページ | Phase 1 | ❌ 未着手 | `docs/PROGRESS.md`（開発者向け）のみ更新継続中 |
+| F-3 | RSS / sitemap 強化 | Phase 1 | ⚠️ **部分達成** | `app/sitemap.ts` + `app/robots.ts` は追加済み。RSS フィードなし |
+| F-4 | ナビ二軸化 | Phase 2 | ❌ 未着手（悪化） | 二軸「設計」なしにトピックカテゴリが 5 → 11 に自然増殖。§5 参照 |
+| F-5 | タグ・横断検索 | Phase 3 | ❌ 未着手 | 56 ルートに到達し 003 の「50 ページ超で必須化」ラインを超過 |
+| F-6 | EN 展開 | Phase 4（ユーザー判断） | ❌ 未着手 | 判断変更なし |
+
+**構図**: 003 §5 が警告した「F-1 を飛ばして拡張するとページ属性がナビ・フィード・タグに複製され
+STATE-01 と同型の歪みを再生産する」がそのまま現実化した。ただし複製先がまだ nav-links.ts 1 箇所に
+留まっている今が、レジストリ導入の最後の低コストタイミングである。
+
+## 5. 新たに顕在化した課題（001 の STATE 系に追加）
+
+### [STATE-06] ナビトップレベルの過密（16 項目）
+
+- **Evidence**: `nav-links.ts:33-169` — Home + プロバイダー 4 + トピック 10 + Git Worktree の 16 項目。
+  うち 1 リンクのみのカテゴリが 3 つ（Sandbox / CI/CD / RAG）、2 リンクが 5 つ（MCP / Local LLM / IDE / Security / Multimodal）
+- **Impact**: 001 STATE-03 の「ドロップダウン破綻」がトップレベル自体で発生。モバイル開閉トグルの一覧性も限界
+- **Confidence**: HIGH（実測）
+
+### [STATE-07] 同一トピックのカテゴリ分散が拡大
+
+- **Evidence**:
+  - Sandbox: ナビ「Sandbox」は 1 リンク（`/vercel/sandbox`）だが、`/claude/self-hosted-sandboxes` は Claude 配下、`/google/sandbox-best-practices` は Google 配下（`nav-links.ts:45,53,124`）
+  - Harness Engineering: 4 ページが Claude / Google ×2 / Codex に分散（001 STATE-01 から未解消）
+  - Security: ナビ「Security」新設後も `/agent/openclaw-advanced-agent-security-guide` は Agent 配下のまま
+- **Impact**: カテゴリを新設するほど「どこに入れるか」の判断がページごとにブレる。レジストリの topics 多対多付けでしか解消しない
+- **Confidence**: HIGH（実測）
+
+### [STATE-08] 鮮度表示の欠如が 56 ページ規模に拡大（STATE-02 の深刻化）
+
+- **Evidence**: 各 page.tsx に最終確認日フィールドなし（変わらず）。monthly-update スキルの 2026-06 実績は
+  14/35 完了で停止しており、残 21 ページ + 新規 21 ページの鮮度が読者からもメンテナーからも見えない
+- **Confidence**: HIGH
+
+## 6. 001〜003 の処遇
+
+- **001**: ルート数・ナビ構成・テスト数が失効 → **STALE**（本ドキュメント §1〜§2 が差分）。§4 の共有インフラ資産・§6 の STATE-01〜05 の枠組みは引き続き有効
+- **002**: カバレッジマップとギャップ判定が失効（GAP-01/03/05/06/07 実装済み、GAP-08/09 決定変更）→ **STALE**。[005](005-category-gap-analysis-v2.md) が置換
+- **003**: Phase 構成の前提（41 ルート・コンテンツより基盤先行）が失効 → **STALE**。[006](006-platform-roadmap-v2.md) が置換。ただし「C 案（URL 不変・ナビとメタデータの二軸化）」「F-1 が依存の要」という設計判断は 006 でも維持
+
+## 7. 次のドキュメントへの接続
+
+- **[005 ギャップ分析 v2](005-category-gap-analysis-v2.md)**: §2〜3 の実装済みカテゴリを新カバレッジマップの基準とし、残ギャップ（GAP-04 モデルトラッキング等）と新候補を判定する
+- **[006 ロードマップ v2](006-platform-roadmap-v2.md)**: §4〜5 の未達 F 項目と STATE-06〜08 を入力に、Phase を再編する

--- a/plans/005-category-gap-analysis-v2.md
+++ b/plans/005-category-gap-analysis-v2.md
@@ -49,13 +49,13 @@
 
 ## 2. 外部トレンド検証（2026-07-12 時点、WebSearch 実施済み）
 
-- **マルチエージェントオーケストレーション**: 導入は前年比 1,445% 増、組織の 57% が本番でマルチステップ
-  エージェントワークフローを運用。fan-out / pipeline / debate / supervisor / swarm の 5 パターンが
-  本番システムの定石として確立。コーディングセッションは平均 4 分 → 23 分に伸び、78% がマルチファイル編集
+- **マルチエージェントオーケストレーション**: エージェント関連の関心・言及量が急伸中（Firecrawl は
+  前年比 1,445% の伸びを報告。ただしこれは「導入率」ではなくトレンド指標である点に注意）。
+  fan-out / pipeline / debate / supervisor / swarm の 5 パターンが本番システムの定石として
+  整理されつつある（Digital Applied / Codebridge）
 - **仕様駆動開発（SDD）**: 2026 年時点で主要 AI コーディングツール（GitHub Spec Kit, AWS Kiro,
-  Claude Code, Cursor, OpenSpec, Google Antigravity 等）がすべて SDD ワークフローを搭載。
-  Spec Kit は v0.11.0（2026-06）で 30+ エージェント対応。早期導入報告では非自明タスクの
-  first-pass 成功率が約 3〜10 倍
+  Claude Code, Cursor, OpenSpec, Google Antigravity 等）が SDD ワークフローを搭載。
+  Spec Kit は複数エージェントへの対応を進めている（版数は流動的なため明記しない）
 
 参照元（確認日 2026-07-12）:
 [Firecrawl: Top 13 Agentic AI Trends 2026](https://www.firecrawl.dev/blog/agentic-ai-trends) /
@@ -75,7 +75,7 @@
 - **Evidence（repo）**: 「サブエージェント/エージェントチーム」言及 **27 ページ**、「マルチエージェント」14 ページ、
   「オーケストレーション」9 ページ — **主題ページは 0**。002 で MCP をカテゴリ化する根拠となった
   「26 ページ言及・主題 0」と同規模のシグナル
-- **Evidence（外部）**: §2 — 導入 1,445% 増、5 パターンの定石化
+- **Evidence（外部）**: §2 — エージェント関連トレンドの急伸、5 パターンの定石化
 - **既存カテゴリとの関係**: Agent 配下が自然（`/agent/loop-engineering` や harness-engineering 群の上位概念）。
   A2A / Agent2Agent プロトコル（言及 2 ページ）はこの中の 1 セクションで扱う
 - **Confidence**: HIGH ／ **想定ページ数**: 2（設計パターン編・運用編）

--- a/plans/005-category-gap-analysis-v2.md
+++ b/plans/005-category-gap-analysis-v2.md
@@ -1,0 +1,148 @@
+# Plan 005: AI 情報収集カテゴリのギャップ分析 v2（Category Gap Analysis v2）
+
+> **本ドキュメントの性格**: [004（照合）](004-reconciliation-2026-07.md) で確定した現状（56 ルート、commit `45940fd`）を
+> 基準に、「AI に関する情報収集・AI 駆動開発のための情報プラットフォーム」として残っている不足カテゴリを、
+> リポジトリ内 evidence と 2026-07 時点の外部トレンドの両面から特定する分析ドキュメント。実装手順は含まない。
+> [002（ギャップ分析 v1）](002-category-gap-analysis.md) を置換する（002 は STALE — 004 §6 参照）。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: —（分析のみ）
+- **Risk**: —
+- **Depends on**: [004-reconciliation-2026-07.md](004-reconciliation-2026-07.md)
+- **Category**: direction
+- **Planned at**: commit `45940fd`, 2026-07-12
+
+## Why this matters
+
+002 のギャップ 9 件のうち 7 件が 1 週間で実装され（004 §2〜3）、プラットフォームは「コーディング
+エージェントの使い方」偏重から大きく広がった。一方で 002 が最も効果的だった予測手法 —
+**「多数のページが断片的に言及しているのに主題ページがないトピック」の検出**（MCP は 26 ページ言及で
+主題 0 だった）— を 56 ルート時点で再実行すると、次の波が既に見えている。
+
+なお読者ペルソナは、Multimodal / NotebookLM / Stitch の採用実績（004 REC-02）を踏まえ、
+002 の「AI 駆動開発者」から「**AI 活用実務者（開発中心）**」へ広げて解釈する。
+
+## 1. 現状カバレッジマップ v2（56 ルート）
+
+| 情報カテゴリ | カバー状況 | 該当ページ数・備考 |
+|---|---|---|
+| コスト計算・料金比較 | ✅ 厚い（自動更新付き） | 電卓ホーム + `/code-review/tool-pricing` |
+| コーディングエージェントの使い方 | ✅ 最も厚い | Claude 10 / Google 12 / Codex 4 / Copilot 4（プロバイダー軸 30） |
+| AI コードレビュー | ✅ | 4 |
+| エージェント設計・運用 | ✅ | Agent 6（context-engineering 含む）+ harness-engineering 4（プロバイダー分散） |
+| MCP | ✅ | 2（入門・中級） |
+| AI セキュリティ | ✅ | 2 + openclaw 1（Agent 配下に分散 — 004 STATE-07） |
+| サンドボックス | ✅ | 3（3 カテゴリに分散 — 004 STATE-07） |
+| 評価・オブザーバビリティ（LLMOps） | ✅ | 1 |
+| AI CI/CD | ✅ | 1 |
+| ローカル LLM | ✅ | 2 |
+| RAG・埋め込み | ✅ | 1 |
+| マルチモーダル生成 | ✅ | 2 |
+| IDE | △ 薄い | 2（Cursor のみ） |
+| Git ワークフロー | △ 単発 | 1 |
+| **マルチエージェントオーケストレーション** | ❌ **主題ページなし** | §3 GAP-10 |
+| **仕様駆動開発（SDD）** | ❌ **主題ページなし** | §3 GAP-11 |
+| **モデルリリース・トラッキング** | ❌（機能としても未実装） | §3 GAP-04'（002 から継続） |
+| AI ガバナンス・コンプライアンス | △ | security-intermediate 内で EU AI Act に言及のみ |
+
+## 2. 外部トレンド検証（2026-07-12 時点、WebSearch 実施済み）
+
+- **マルチエージェントオーケストレーション**: 導入は前年比 1,445% 増、組織の 57% が本番でマルチステップ
+  エージェントワークフローを運用。fan-out / pipeline / debate / supervisor / swarm の 5 パターンが
+  本番システムの定石として確立。コーディングセッションは平均 4 分 → 23 分に伸び、78% がマルチファイル編集
+- **仕様駆動開発（SDD）**: 2026 年時点で主要 AI コーディングツール（GitHub Spec Kit, AWS Kiro,
+  Claude Code, Cursor, OpenSpec, Google Antigravity 等）がすべて SDD ワークフローを搭載。
+  Spec Kit は v0.11.0（2026-06）で 30+ エージェント対応。早期導入報告では非自明タスクの
+  first-pass 成功率が約 3〜10 倍
+
+参照元（確認日 2026-07-12）:
+[Firecrawl: Top 13 Agentic AI Trends 2026](https://www.firecrawl.dev/blog/agentic-ai-trends) /
+[Digital Applied: Multi-Agent Orchestration 5 Patterns](https://www.digitalapplied.com/blog/multi-agent-orchestration-5-patterns-that-work) /
+[Codebridge: Mastering Multi-Agent Orchestration](https://www.codebridge.tech/articles/mastering-multi-agent-orchestration-coordination-is-the-new-scale-frontier) /
+[GitHub Blog: Spec-driven development with AI](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/) /
+[BCMS: Spec-Driven Development 2026 Guide](https://thebcms.com/blog/spec-driven-development) /
+[github/spec-kit](https://github.com/github/spec-kit)
+
+## 3. ギャップ候補（優先度順）
+
+各候補の repo 内言及数は 2026-07-12 に `grep -rl <keyword> --include='page.tsx' web-next/app` で実測。
+番号は 002 の GAP-01〜09 から継続する。
+
+### [GAP-10] マルチエージェントオーケストレーション — 優先度 High
+
+- **Evidence（repo）**: 「サブエージェント/エージェントチーム」言及 **27 ページ**、「マルチエージェント」14 ページ、
+  「オーケストレーション」9 ページ — **主題ページは 0**。002 で MCP をカテゴリ化する根拠となった
+  「26 ページ言及・主題 0」と同規模のシグナル
+- **Evidence（外部）**: §2 — 導入 1,445% 増、5 パターンの定石化
+- **既存カテゴリとの関係**: Agent 配下が自然（`/agent/loop-engineering` や harness-engineering 群の上位概念）。
+  A2A / Agent2Agent プロトコル（言及 2 ページ）はこの中の 1 セクションで扱う
+- **Confidence**: HIGH ／ **想定ページ数**: 2（設計パターン編・運用編）
+
+### [GAP-11] 仕様駆動開発（Spec-Driven Development） — 優先度 High
+
+- **Evidence（repo）**: 「仕様駆動」5 ページ + 「spec-driven / Spec Kit」6 ページが断片言及 — 主題ページ 0。
+  このリポジトリ自体が requirements/design/tasks 構造のスキル
+  （`.agent/skills/ai-driven-development-guidelines`）を運用しており「自分で実践しているのに解説がない」
+  状態（002 GAP-06 で AI CI/CD をカテゴリ化したのと同じシグナル）
+- **Evidence（外部）**: §2 — 主要全ツールが SDD 搭載、業界標準化が進行
+- **既存カテゴリとの関係**: 特定プロバイダーに属さない開発プロセス論。新トピックまたは Agent 配下
+- **Confidence**: HIGH ／ **想定ページ数**: 1〜2（概念 + Spec Kit 等ツール比較）
+
+### [GAP-04'] モデルリリース・アップデートトラッキング — 優先度 High（002 から継続）
+
+- **Evidence（repo）**: 「モデルリリース/リリースノート」言及 13 ページ。scraper + monthly-update という
+  鮮度維持の仕組みは価格のみ対象のまま（004 §4 F-1/F-2 未着手）。002 時点から**唯一実装されなかった High**
+- **性格**: ページ群ではなく**プラットフォーム機能**（What's New / 鮮度表示）。[006](006-platform-roadmap-v2.md) Phase 1 で扱う
+- **Confidence**: HIGH
+
+### [GAP-12] AI ガバナンス・コンプライアンス — 優先度 Mid
+
+- **Evidence（repo）**: 「ガバナンス」言及 10 ページ、「EU AI Act」5 ページ。
+  `/security/ai-security-best-practices-intermediate` が EU AI Act に触れており、「1 ページ（の一部）だけある」
+  カテゴリ化直前シグナル（002 GAP-03 で Security を予測したパターンの再来）
+- **判断**: 独立カテゴリではなく **Security カテゴリの深化**（§4 の判断基準 D-1 適用）。
+  規制動向は変化が速く monthly-update の負担になるため、原則論（AI 利用ポリシー設計・監査ログ・データ取扱）中心で 1 ページ
+- **Confidence**: MED ／ **想定ページ数**: 1（Security 配下）
+
+### [GAP-13] ファインチューニング / モデルカスタマイズ — 優先度 Low〜Mid
+
+- **Evidence（repo）**: 言及 10 ページ。`/local-llm/` 2 ページが隣接（セルフホストの次の実務ステップ）
+- **判断**: 独立カテゴリにせず **Local LLM カテゴリの深化**として 1 ページ。クラウド API のファインチューニング
+  はコスト観点で電卓との相性も良い
+- **Confidence**: LOW（ペルソナ適合は要観察）／ **想定ページ数**: 1（Local LLM 配下）
+
+### [GAP-14] 音声・リアルタイムエージェント — 採否判断: Multimodal へ吸収を推奨
+
+- **Evidence（repo）**: 「音声」9 ページ、「リアルタイム」22 ページ（ただし大半はリアルタイム処理一般の文脈）。
+  `/multimodal/image-audio-best-practices-2026` が音声生成を既にカバー
+- **判断**: 新カテゴリ・新ページとも起こさず、既存 Multimodal 2 ページの次回 monthly-update で
+  リアルタイム音声エージェント（Realtime API 系）のセクション追記に留める
+- **Confidence**: MED（吸収判断について）
+
+## 4. カテゴリ「深化 vs 新設」の判断基準
+
+004 STATE-06 のとおりナビトップレベルは 16 項目で飽和しており、1〜2 リンクのカテゴリが 8 つある。
+今後は以下を満たす場合のみ新カテゴリを起こす（すべて AND）:
+
+- **D-1**: 既存カテゴリのどの切り口とも重ならない主題である（重なるなら既存カテゴリの深化）
+- **D-2**: 初回から 2 ページ以上を計画できる（1 ページなら既存カテゴリ配下に置き、増えた時点で昇格）
+- **D-3**: [006](006-platform-roadmap-v2.md) の IA 再編後の大分類に収まる場所が特定できる
+
+本分析への適用結果: GAP-10（Agent 配下で開始 → 需要次第で昇格）、GAP-11（新設候補だが 1 ページ開始なら
+Agent 配下）、GAP-12（Security 深化）、GAP-13（Local LLM 深化）、GAP-14（Multimodal 追記のみ）。
+
+## 5. 推奨カテゴリ体系 v2（006 への入力）
+
+```text
+コンテンツ追加（High）:  マルチエージェントオーケストレーション（GAP-10, Agent 配下 2 ページ）
+                        仕様駆動開発 SDD（GAP-11, 1〜2 ページ）
+機能として追加（High）:  モデルリリース・トラッキング（GAP-04' → 006 Phase 1: registry + What's New）
+深化（Mid〜Low）:        AI ガバナンス（GAP-12, Security 配下 1）/ ファインチューニング（GAP-13, Local LLM 配下 1）
+吸収（新ページなし）:     音声・リアルタイム（GAP-14 → Multimodal 既存ページへ追記）
+```
+
+新規ページの実装は既存の確立パターン（`.claude/skills/nextjs-page-migration/` の TDD 手順、契約テスト、
+CSS Modules、`components/docs/` 共有コンポーネント、`.claude/rules/tdd-mandatory-cycle.md` のコミット分割）に
+完全準拠する。ナビ配置は 006 の IA 再編（トピック大分類）を前提とする。

--- a/plans/006-platform-roadmap-v2.md
+++ b/plans/006-platform-roadmap-v2.md
@@ -1,0 +1,150 @@
+# Plan 006: AI 最新情報キャッチアップ・プラットフォーム拡張ロードマップ v2
+
+> **本ドキュメントの性格**: [004（照合）](004-reconciliation-2026-07.md) の未達項目・新課題 STATE-06〜08 と
+> [005（ギャップ分析 v2）](005-category-gap-analysis-v2.md) の GAP-10〜14 を入力に、
+> プラットフォームの目指す構成・実施順序・トレードオフを再定義する方向性ドキュメント。
+> [003（ロードマップ v1）](003-platform-expansion-roadmap.md) を置換する（003 は STALE — 004 §6 参照）。
+> **本ドキュメント自体は実装しない**。各項目は着手時に improve スキルの `plan <description>` で
+> 個別の実行プラン（`plans/NNN-*.md`）へ分割する。
+
+## Status
+
+- **Priority**: P1（方向性の合意が全プランの前提）
+- **Effort**: 項目別に記載（direction のため概算 — 精緻化は個別プラン時）
+- **Risk**: 項目別に記載
+- **Depends on**: [004](004-reconciliation-2026-07.md), [005](005-category-gap-analysis-v2.md)
+- **Category**: direction
+- **Planned at**: commit `45940fd`, 2026-07-12
+
+## 1. 目標像の再確認と現在地
+
+003 §1 の目標像は変更しない:
+
+> 「AI 駆動開発の実務者が、**信頼できる鮮度表示付き**で、プロバイダー横断のトピック軸から
+> 最新のツール・プロトコル・手法をキャッチアップできる日本語プラットフォーム」
+
+003 が挙げた 3 差分の現在地（004 で照合済み）:
+
+| 差分 | 003 時点 | 現在（56 ルート） |
+|---|---|---|
+| 1. 鮮度が見えない | 未解消 | **未解消のまま対象が 41 → 55 ページに拡大**（STATE-08）。最大の負債 |
+| 2. トピック軸が弱い | 未解消 | **カテゴリ数としては解消**（トピック 11 カテゴリ）。ただし設計なき増殖でトップレベル過密（STATE-06）と分散（STATE-07）が発生 |
+| 3. 横断導線がない | 未解消 | 未解消。sitemap.ts は追加されたが読者向け導線（検索・タグ・関連リンク）はゼロ |
+
+**v2 の基本認識**: コンテンツの量と幅は既に「プラットフォーム」水準に達した。ボトルネックは
+コンテンツではなく**構造（鮮度・ナビ・横断導線）**に完全に移った。よって v2 では
+「基盤 → コンテンツ」の順序を v1 以上に強く強制する。
+
+## 2. 情報アーキテクチャ（IA）再設計
+
+### 2.1 原則の維持
+
+003 §2 の **C 案（URL 不変・ナビとメタデータのみ二軸化）** を維持する。理由も同一:
+既存 56 URL は外部参照されており、`output: 'export'` + Netlify 構成でのリダイレクトは
+netlify.toml 変更（AI 変更ルールで原則禁止・要ユーザー承認）を伴うため。
+
+### 2.2 ナビトップレベルの再グルーピング（STATE-06 対応）
+
+現行 16 項目を **8 項目**へ集約する案（個別プラン時に確定。リンク数は 2026-07-12 実測）:
+
+```text
+Home（電卓）
+Providers ▾        … Claude 10 / Google 12 / Codex 4 / Copilot 4 の 2 段ネスト（計 30）
+Agent 開発 ▾       … Agent 6 + MCP 2 + Sandbox 3（分散解消） + オーケストレーション/SDD（GAP-10/11 受け皿）
+開発プロセス ▾     … Code Review 4 + CI/CD 1 + IDE 2 + Git Worktree 1
+運用・品質 ▾       … Security 2+1（openclaw 移設） + LLMOps 1 + ガバナンス（GAP-12 受け皿）
+モデル・データ ▾   … Local LLM 2 + RAG 1 + Multimodal 2 + ファインチューニング（GAP-13 受け皿）
+What's New         … Phase 1 の F-2（新設）
+```
+
+- 2 段ネスト（グループ → カテゴリ → ページ）は現行 `DropdownSchema`（`nav-links.ts:22-25`）が
+  1 段しか表現できないため、スキーマ拡張が必要 — これは F-4' の実装論点（契約テスト更新を含む）
+- グルーピングは**レジストリの topics から導出**する構造にし、nav-links.ts への直書きを段階的に廃止する
+- ラベルは案であり、個別プラン時に読者導線（どの語で探すか）を基準に確定する
+
+### 2.3 メタデータ SSoT: ページレジストリ（F-1、v1 から変更なし・最優先を再宣言）
+
+```text
+web-next/lib/page-registry.ts（新設・概念形）
+  { slug, title, provider?, topics[], group, addedAt, lastReviewed, summary }
+```
+
+- `nav-links.ts` の Zod 検証パターンを踏襲。ナビ・What's New・鮮度表示・タグ・RSS すべてを
+  registry から導出する
+- 契約テストで「全 page.tsx が registry に登録済み」を機械検証（既存テストパターンで実現可能）
+- **コスト上方修正**: 対象 55 ページ（v1 時点 40）。`addedAt` は `git log --follow --diff-filter=A` で、
+  `lastReviewed` は monthly-update の 2026-06 実績（14/35）と `docs/PROGRESS.md` から初期値を機械的に採取する
+- **これ以上遅らせるほど初期値投入コストが増える**。004 §4 のとおり、属性の複製先がまだ
+  nav-links.ts 1 箇所である今が最後の低コストタイミング
+
+## 3. フェーズ再編（v2）
+
+```text
+Phase 1: 鮮度基盤（最優先・他のすべての前提）
+  F-1  ページレジストリ + 各ページの最終確認日表示     Impact High / Effort L / Risk LOW
+  F-2  What's New ページ（registry から静的生成）       Impact High / Effort S〜M / Risk LOW
+  F-2' monthly-update スキルとの接続 — 確認結果を lastReviewed へ書き戻す運用の確立
+       （2026-06 実績 14/35 の残 21 ページ + 新規 21 ページの棚卸しを初回データ投入と兼ねる）
+
+Phase 2: IA 再編（STATE-06/07 対応）
+  F-4' ナビ再グルーピング（§2.2）+ スキーマ 2 段ネスト化   Impact High / Effort M / Risk MED
+       （nav-links 契約テスト・全ページの page.test.tsx への影響を個別プランで精査）
+
+Phase 3: 横断導線
+  F-3' RSS フィード（registry から生成。sitemap.ts は既存）  Impact Mid / Effort S / Risk LOW
+  F-5  タグ・横断検索（ビルド時インデックス）               Impact High / Effort L / Risk MED
+       （検索ライブラリ追加は外部依存 — 要ユーザー承認。自前実装で回避可なら回避）
+  F-7  関連ページリンク（registry の topics 近接から導出）   Impact Mid / Effort S / Risk LOW（新規）
+
+Phase 4: コンテンツ拡張（005 の採用分 — Phase 1 完了後に着手）
+  C-10 マルチエージェントオーケストレーション 2 ページ（GAP-10, High）
+  C-11 仕様駆動開発 SDD 1〜2 ページ（GAP-11, High）
+  C-12 AI ガバナンス 1 ページ — Security 深化（GAP-12, Mid）
+  C-13 ファインチューニング 1 ページ — Local LLM 深化（GAP-13, Low〜Mid）
+  （GAP-14 音声・リアルタイムは新ページなし — Multimodal 既存ページへの追記で対応）
+
+Phase 5（任意・ユーザー判断待ち）:
+  F-6  EN 展開（JA 固定は CLAUDE.md 記載の設計判断 — 変更はユーザー判断事項）
+```
+
+- **依存の要は引き続き F-1**。F-2 / F-3' / F-4' / F-5 / F-7 はすべて registry から導出する
+- **Phase 4 を Phase 1 の後に置くのが v2 の核心**: 004 で確認したとおり、v1 では
+  コンテンツが基盤より先行して STATE-06〜08 を生んだ。新規ページは「registry 登録 + 鮮度表示付き」で
+  生まれる状態になってから追加する
+- 例外: 緊急性の高い時事コンテンツ（新モデル・新ツールのリリース対応）は Phase 1 完了を待たずに
+  追加してよいが、その場合も nav-links 追加時に registry 移行対象であることをコミットメッセージに残す
+
+## 4. 運用との接続（monthly-update / docs-sync）
+
+- F-1 の `lastReviewed` は `.claude/skills/monthly-update/` の確認プロセスと一体化する:
+  月次確認の完了 = registry の該当エントリ更新 = サイト上の鮮度表示更新、が 1 コミットで閉じる
+- `docs/PROGRESS.md`（開発者向け）と What's New（読者向け）の二重管理を避けるため、
+  F-2 実装時に「What's New は registry の `addedAt` から自動導出、PROGRESS.md は開発詳細のみ」と
+  役割を分離する
+- 週次〜月次で `.agent/skills/improve/SKILL.md` の `reconcile` を回し、本ドキュメントと実装の
+  ドリフトを README のステータス表へ反映する（今回 004 が初回実施）
+
+## 5. 個別プラン化の指針（実装着手時）
+
+1. 各項目は improve スキルの `plan <description>` で `plans/NNN-*.md` として起票する
+   （例: `plan F-1 ページレジストリと最終確認日表示の導入`）。F-4'（スキーマ変更を伴う）と
+   F-5 は build プランではなく **design/spike プラン**から始める
+2. 個別プランは `.agent/skills/improve/references/plan-template.md` に準拠し、
+   TDD ルール（`.claude/rules/tdd-mandatory-cycle.md`: Red → Green → Refactor → Docs Sync の
+   コミット分割）を Steps に織り込む
+3. **ユーザー確認が必須の項目**: URL 移動・リダイレクト（netlify.toml）、検索ライブラリ等の
+   外部依存追加（F-5）、EN 展開（F-6）、ナビ大規模変更（F-4' — 全ページの見え方が変わるため
+   着手前に §2.2 のグルーピング案の承認を得る）
+4. **STOP 条件の共通形**: nav-links.ts / ルート数 / 契約テストの期待値が本ドキュメント作成時
+   （commit `45940fd`, 56 ルート・ナビ 16 項目・テスト 931 件）から乖離していた場合は、
+   improve `reconcile` による再照合（004 の更新または 007 起票）から始める
+
+## 6. 本ロードマップで扱わないこと（rejected）
+
+- **URL 全面再編（トピック軸 URL への移動）**: v1 から継続して不採用。C 案（§2.1）で目的を達成できる限り実施しない
+- **CMS / DB の導入**: pure SSG + Git 管理の強みを放棄する理由がない（v1 から継続）
+- **音声・リアルタイムエージェントの新カテゴリ／新ページ**: 005 GAP-14 のとおり Multimodal 既存ページへの追記で対応
+- **1 ページ規模の新カテゴリ乱立**: 005 §4 の判断基準 D-1〜D-3 を満たさない限りカテゴリを新設しない
+
+（v1 で rejected だった RAG 独立カテゴリ・マルチモーダルは 004 §3 のとおり採用済みへ決定変更 —
+本リストからは削除）

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,69 @@
+# Plans — プラットフォーム拡張検討ドキュメント
+
+`.agent/skills/improve/SKILL.md` により生成・維持している方向性ドキュメント群。
+対象は web-next（Next.js 16 SSG）の「AI 最新情報キャッチアップ・プラットフォーム」化。
+001〜006 は**分析・方向性ドキュメント**であり、そのまま実装するものではない。
+実装着手時は 006 §5 の指針に従い、項目ごとに個別プラン（`plans/NNN-*.md`）を起票する。
+
+- 初回生成: 2026-07-06（001〜003, commit `3915136`）
+- 照合 v2: 2026-07-12（004〜006, commit `45940fd`）— 154 コミットのドリフトを 004 で照合済み
+
+基準コミット（drift 検出用）: `45940fd`
+
+## 実行順・ステータス
+
+| Plan | タイトル | 種別 | Depends on | Status |
+|------|---------|------|------------|--------|
+| [001](001-current-state-analysis.md) | web-next プラットフォーム現状分析 | 分析 | — | **STALE**（004 §1〜2 が差分。STATE-01〜05 の枠組みは有効） |
+| [002](002-category-gap-analysis.md) | AI 情報収集カテゴリのギャップ分析 | 分析 | 001 | **STALE**（005 が置換） |
+| [003](003-platform-expansion-roadmap.md) | プラットフォーム拡張ロードマップ | direction | 001, 002 | **STALE**（006 が置換。C 案・F-1 最優先の判断は継承） |
+| [004](004-reconciliation-2026-07.md) | 照合 — 001〜003 と現状の突合 | reconcile | 001–003 | DONE（照合完了） |
+| [005](005-category-gap-analysis-v2.md) | カテゴリギャップ分析 v2（56 ルート） | direction | 004 | DONE（分析完了） |
+| [006](006-platform-roadmap-v2.md) | プラットフォーム拡張ロードマップ v2 | direction | 004, 005 | DONE（方向性定義完了） |
+| 007 | Phase 1 鮮度基盤（F-1 ページレジストリ + F-2 What's New） | build | 006 | **DONE**（2026-07-13 実装完了。下記「Phase 1 実装結果」参照） |
+
+Status 値: TODO / IN PROGRESS / DONE / BLOCKED（理由 1 行） / REJECTED（理由 1 行） / STALE（置換先を明記）
+
+## Phase 1 実装結果（2026-07-13）
+
+006 §3 の Phase 1（F-1 / F-2 / F-2'）を実装済み。
+
+- `web-next/lib/page-registry.ts` — 57 エントリ（Home + 55 ガイド + What's New）の SSoT。Zod 検証付き
+- `web-next/components/site/PageFreshness.tsx` — `app/layout.tsx` に 1 箇所マウントし全ページに
+  「最終確認日 / 公開日」を表示（55 個の page.tsx は未編集）
+- `web-next/app/whats-new/page.tsx` — 新着 / 最近更新を registry から静的生成
+- `web-next/app/sitemap.ts` — registry 駆動へ置換（24 → 57 ルート。欠落 31 ルートを解消）
+- `.claude/skills/monthly-update/SKILL.md` §4.5 — F-2'：月次確認で `lastReviewed` を書き戻す運用を確立
+- テスト 1040 件 全 Green（契約テスト 44 件追加）
+
+**次は Phase 2（F-4' ナビ再グルーピング）**。着手前に 006 §2.2 のグルーピング案のユーザー承認が必要。
+registry の `group` フィールドには 8 グループ体系を先行投入済みのため、ナビ側の差し替えのみで済む。
+
+## 依存関係
+
+- 004 は 001〜003 の記述と commit `45940fd` 時点の実装を突合した照合結果（STALE 判定の根拠）
+- 005 は 004 §2〜3 の実装済みカテゴリを新カバレッジマップの基準とする
+- 006 は 004 の未達 F 項目・STATE-06〜08 と 005 の GAP-10〜14 を入力とする
+- 実装フェーズの依存の要は引き続き **F-1 ページレジストリ**（006 §2.3）— 他の全機能の前提
+
+## 次のアクション（実装起票の推奨順 — 006 §3 準拠）
+
+1. ~~`plan F-1 ページレジストリと最終確認日表示の導入`~~ → **DONE**（2026-07-13）
+2. ~~`plan F-2 What's New ページの静的生成 + monthly-update との lastReviewed 接続`~~ → **DONE**（2026-07-13）
+3. `plan F-4' ナビ再グルーピング（17 → 8 項目・2 段ネスト化）の design spike`（着手前にグルーピング案のユーザー承認必須）
+4. Phase 4 コンテンツ（C-10 オーケストレーション / C-11 SDD）は Phase 1 完了済みのため着手可能
+
+## 検討済み・不採用（re-audit 防止）
+
+- **URL 全面再編（トピック軸 URL への移動）**: リダイレクトが netlify.toml 変更を要し AI 変更ルールに抵触。ナビ再編（006 §2.2）で代替
+- **CMS / DB 導入**: pure SSG + Git 管理の強みを放棄する理由がない（006 §6）
+- **音声・リアルタイムエージェントの新カテゴリ**: Multimodal 既存ページへの追記で対応（005 GAP-14）
+- **1 ページ規模の新カテゴリ新設**: 005 §4 の判断基準 D-1〜D-3 を満たす場合のみ許可
+- ~~マルチモーダル / RAG 独立カテゴリの不採用~~ → **2026-07-08 前後のユーザー判断で採用・実装済みへ決定変更**（004 §3）
+
+## 制約メモ（全プラン共通）
+
+- コード実装時は `.claude/rules/tdd-mandatory-cycle.md`（Red → Green → Refactor → Docs Sync）を厳守
+- netlify.toml・外部依存追加・EN 展開・ナビ大規模変更はユーザー明示承認が必要（006 §5）
+- コミット前 PII チェック（`.claude/rules/no-absolute-paths.md`）を全コミットで実施
+- plans/ は 2026-07-12 に Git 追跡へ復帰済み（`.gitignore` の `/plans/` をコメントアウト）。ドキュメント更新もコミット対象

--- a/plans/README.md
+++ b/plans/README.md
@@ -32,7 +32,7 @@ Status 値: TODO / IN PROGRESS / DONE / BLOCKED（理由 1 行） / REJECTED（�
 - `web-next/components/site/PageFreshness.tsx` — `app/layout.tsx` に 1 箇所マウントし全ページに
   「最終確認日 / 公開日」を表示（55 個の page.tsx は未編集）
 - `web-next/app/whats-new/page.tsx` — 新着 / 最近更新を registry から静的生成
-- `web-next/app/sitemap.ts` — registry 駆動へ置換（24 → 57 ルート。欠落 31 ルートを解消）
+- `web-next/app/sitemap.ts` — registry 駆動へ置換（24 → 57 ルート。欠落 33 ルートを解消）
 - `.claude/skills/monthly-update/SKILL.md` §4.5 — F-2'：月次確認で `lastReviewed` を書き戻す運用を確立
 - テスト 1040 件 全 Green（契約テスト 44 件追加）
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,8 +29,11 @@ sonar.exclusions=web-next/.next/**,web-next/out/**,web-next/node_modules/**,scra
 # 注: web-next/app/**/page.tsx は静的コンテンツ主体（ロジックは lib/・components/ 側）。
 #     行カバレッジ追跡に意味がなく、構造検証は page.test.tsx（契約テスト）が担うため除外する。
 sonar.coverage.exclusions=**/*.test.*,web-next/tests/**,scraper/tests/**,**/*.config.*,web-next/app/**/page.tsx
-# 重複検出（CPD）から除外: ガイドページはカード/セクション構造の反復が本質で、
-# 共通化は可読性を損なうため重複として扱わない。
-sonar.cpd.exclusions=web-next/app/**/page.tsx
+# 重複検出（CPD）から除外:
+# - ガイドページはカード/セクション構造の反復が本質で、共通化は可読性を損なう。
+# - page-registry.ts は全ページのメタデータを列挙するデータテーブル（SSoT）。
+#   同一キー列の反復は構造上不可避で、ロジック重複ではない（CPD はトークン列で照合するため
+#   大きなオブジェクト literal の配列は必然的に重複判定される）。
+sonar.cpd.exclusions=web-next/app/**/page.tsx,web-next/lib/page-registry.ts
 
 sonar.sourceEncoding=UTF-8

--- a/web-next/app/code-review/coderabbit-guide/layout.tsx
+++ b/web-next/app/code-review/coderabbit-guide/layout.tsx
@@ -10,6 +10,12 @@ export const metadata: Metadata = {
   description: "AI コードレビューツール CodeRabbit の導入・設定・運用を解説する実践ガイド。",
 };
 
+/**
+ * Renders the content provided to the route layout.
+ *
+ * @param children - The content to render within the layout
+ * @returns The provided content
+ */
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/web-next/app/code-review/coderabbit-guide/layout.tsx
+++ b/web-next/app/code-review/coderabbit-guide/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+/**
+ * page.tsx が "use client" のため、Next.js の規約により metadata を page から export できない。
+ * ルート単位の layout（Server Component）で SEO メタデータを供給する。
+ * description は lib/page-registry.ts の summary と同一文言に揃えている。
+ */
+export const metadata: Metadata = {
+  title: "CodeRabbit 実践ガイド — AI コードレビューの導入と運用 | LLM-Studies",
+  description: "AI コードレビューツール CodeRabbit の導入・設定・運用を解説する実践ガイド。",
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web-next/app/code-review/coderabbit-guide/page.test.tsx
+++ b/web-next/app/code-review/coderabbit-guide/page.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
+import type { Metadata } from "next";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import Page from "./page";
+import Page, { metadata } from "./page";
 
 beforeAll(() => {
   global.IntersectionObserver = class {
@@ -49,5 +50,19 @@ describe("/code-review/coderabbit-guide", () => {
     const { container } = render(<Page />);
     const codeBlocks = container.querySelectorAll("pre, code");
     expect(codeBlocks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("/code-review/coderabbit-guide metadata", () => {
+  it("metadata が export されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.title).toBe("string");
+    expect(meta.title).toContain("CodeRabbit");
+  });
+
+  it("description が設定されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.description).toBe("string");
+    expect((meta.description ?? "").length).toBeGreaterThan(20);
   });
 });

--- a/web-next/app/code-review/coderabbit-guide/page.test.tsx
+++ b/web-next/app/code-review/coderabbit-guide/page.test.tsx
@@ -1,7 +1,9 @@
 import { render } from "@testing-library/react";
 import type { Metadata } from "next";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import Page, { metadata } from "./page";
+// page.tsx は "use client" のため metadata を持てない。Next.js の規約どおり layout.tsx から export する。
+import { metadata } from "./layout";
+import Page from "./page";
 
 beforeAll(() => {
   global.IntersectionObserver = class {

--- a/web-next/app/code-review/sonar-qube/layout.tsx
+++ b/web-next/app/code-review/sonar-qube/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+/**
+ * page.tsx が "use client" のため、Next.js の規約により metadata を page から export できない。
+ * ルート単位の layout（Server Component）で SEO メタデータを供給する。
+ * description は lib/page-registry.ts の summary と同一文言に揃えている。
+ */
+export const metadata: Metadata = {
+  title: "SonarQube Code Review 実践ガイド — 静的解析と品質ゲート | LLM-Studies",
+  description:
+    "SonarQube による静的解析とコード品質ゲートの実践ガイド。CI 連携とカバレッジ計測を解説。",
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web-next/app/code-review/sonar-qube/layout.tsx
+++ b/web-next/app/code-review/sonar-qube/layout.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
     "SonarQube による静的解析とコード品質ゲートの実践ガイド。CI 連携とカバレッジ計測を解説。",
 };
 
+/**
+ * Renders the route content as provided.
+ *
+ * @returns The supplied route content
+ */
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/web-next/app/code-review/sonar-qube/page.test.tsx
+++ b/web-next/app/code-review/sonar-qube/page.test.tsx
@@ -1,7 +1,9 @@
 import { render } from "@testing-library/react";
 import type { Metadata } from "next";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import Page, { metadata } from "./page";
+// page.tsx は "use client" のため metadata を持てない。Next.js の規約どおり layout.tsx から export する。
+import { metadata } from "./layout";
+import Page from "./page";
 
 beforeAll(() => {
   global.IntersectionObserver = class {

--- a/web-next/app/code-review/sonar-qube/page.test.tsx
+++ b/web-next/app/code-review/sonar-qube/page.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
+import type { Metadata } from "next";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import Page from "./page";
+import Page, { metadata } from "./page";
 
 beforeAll(() => {
   global.IntersectionObserver = class {
@@ -47,5 +48,19 @@ describe("/code-review/sonar-qube", () => {
     const { container } = render(<Page />);
     const codeBlocks = container.querySelectorAll("pre, code");
     expect(codeBlocks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("/code-review/sonar-qube metadata", () => {
+  it("metadata が export されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.title).toBe("string");
+    expect(meta.title).toContain("SonarQube");
+  });
+
+  it("description が設定されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.description).toBe("string");
+    expect((meta.description ?? "").length).toBeGreaterThan(20);
   });
 });

--- a/web-next/app/codex/harness-engineering/page.test.tsx
+++ b/web-next/app/codex/harness-engineering/page.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
+import type { Metadata } from "next";
 import { describe, expect, it, vi } from "vitest";
-import Page from "./page";
+import Page, { metadata } from "./page";
 
 vi.mock("@/components/docs/MermaidDiagram", () => ({
   default: function DummyMermaidDiagram({ chart }: { chart: string }) {
@@ -74,5 +75,19 @@ describe("OpenAI Harness Engineering Guide", () => {
       el.className?.includes("codeWrap")
     );
     expect(codeBlocks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("/codex/harness-engineering metadata", () => {
+  it("metadata が export されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.title).toBe("string");
+    expect(meta.title).toContain("ハーネスエンジニアリング");
+  });
+
+  it("description が設定されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.description).toBe("string");
+    expect((meta.description ?? "").length).toBeGreaterThan(20);
   });
 });

--- a/web-next/app/codex/harness-engineering/page.tsx
+++ b/web-next/app/codex/harness-engineering/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import MermaidDiagram from "@/components/docs/MermaidDiagram";
 import styles from "./page.module.css";
+
+/** description は lib/page-registry.ts の summary と同一文言に揃えている。 */
+export const metadata: Metadata = {
+  title: "ハーネスエンジニアリング完全ガイド — OpenAI Codex | LLM-Studies",
+  description:
+    "OpenAI Codex のハーネスエンジニアリング完全ガイド。エージェント実行環境の設計と運用。",
+};
 
 const DIAGRAM_0 = `flowchart LR
 A["評価目標の定義\\nWhat to measure"]

--- a/web-next/app/layout.tsx
+++ b/web-next/app/layout.tsx
@@ -1,4 +1,5 @@
 import { DisclaimerBanner } from "@/components/site/DisclaimerBanner";
+import { PageFreshness } from "@/components/site/PageFreshness";
 import { SiteHeader } from "@/components/site/SiteHeader";
 import { jetbrainsMono, notoSansJp, syne } from "@/lib/fonts";
 import "./globals.css";
@@ -21,6 +22,7 @@ export default function RootLayout({
       <body className="has-common-header">
         <SiteHeader />
         <DisclaimerBanner />
+        <PageFreshness />
         {children}
       </body>
     </html>

--- a/web-next/app/sitemap.test.ts
+++ b/web-next/app/sitemap.test.ts
@@ -1,0 +1,47 @@
+/**
+ * F-1c 契約テスト: sitemap を page-registry から導出する。
+ *
+ * 従来はハードコードの ROUTES 配列（24 件）で、実ルート 55 と乖離していた
+ * （plans/006 §2.3 が指摘する「属性の複製先が増えると腐る」の実例）。
+ */
+import { describe, expect, it } from "vitest";
+import { pageRegistry } from "@/lib/page-registry";
+import sitemap from "./sitemap";
+
+const entries = sitemap();
+
+describe("sitemap", () => {
+  it("registry の全ページ分のエントリを出力する", () => {
+    expect(entries).toHaveLength(pageRegistry.length);
+  });
+
+  it("registry の全 slug が URL に含まれる（欠落ルート検知）", () => {
+    const urls = entries.map((e) => e.url);
+    for (const page of pageRegistry) {
+      const expected = page.slug === "/" ? "/" : page.slug;
+      expect(urls.some((u) => new URL(u).pathname === expected)).toBe(true);
+    }
+  });
+
+  it("lastModified に該当ページの lastReviewed を反映する", () => {
+    const skill = pageRegistry.find((e) => e.slug === "/claude/skill");
+    const entry = entries.find((e) => new URL(e.url).pathname === "/claude/skill");
+    expect(entry?.lastModified).toBe(skill?.lastReviewed);
+  });
+
+  it("全 URL が絶対 URL（http/https）である", () => {
+    for (const e of entries) {
+      expect(e.url).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it("ルート（/）の priority が最も高い", () => {
+    const root = entries.find((e) => new URL(e.url).pathname === "/");
+    expect(root?.priority).toBe(1.0);
+    for (const e of entries) {
+      if (new URL(e.url).pathname !== "/") {
+        expect(e.priority).toBeLessThan(1.0);
+      }
+    }
+  });
+});

--- a/web-next/app/sitemap.ts
+++ b/web-next/app/sitemap.ts
@@ -8,16 +8,12 @@ export const dynamic = "force-static";
 const SITE_URL = resolveSiteUrl("sitemap.ts");
 
 /**
- * Generate sitemap entries from the page registry (plans/006 §2.3 の F-1c)。
+ * Generates sitemap entries for all pages in the page registry.
  *
- * ハードコードのルート一覧は 24 件で止まり実ルート 55 と乖離していたため、
- * lib/page-registry.ts を唯一の導出元にする。新規ページは registry 登録だけで
- * sitemap に載る（登録漏れは tests/page-registry-coverage.test.ts が検知する）。
+ * Uses each page's last review date and assigns higher priority and weekly updates
+ * to the site root.
  *
- * `lastModified` にはページの `lastReviewed`（人間が内容を確認した日）を使う。
- * ビルド日時ではなく実際の確認日を出すことで、クローラーに正しい鮮度を伝える。
- *
- * @returns 各エントリが url / lastModified / changeFrequency / priority を持つ sitemap 配列
+ * @returns Sitemap entries containing each page's URL, review date, update frequency, and priority.
  */
 export default function sitemap(): MetadataRoute.Sitemap {
   return pageRegistry.map((page) => {

--- a/web-next/app/sitemap.ts
+++ b/web-next/app/sitemap.ts
@@ -1,58 +1,32 @@
 import type { MetadataRoute } from "next";
 
+import { pageRegistry } from "@/lib/page-registry";
 import { resolveSiteUrl } from "@/lib/site-url";
 
 export const dynamic = "force-static";
 
 const SITE_URL = resolveSiteUrl("sitemap.ts");
 
-const ROUTES = [
-  "/",
-  // Phase B: skill.html × 4
-  "/claude/skill",
-  "/google/skill",
-  "/codex/skill",
-  "/copilot/skill",
-  // Phase C: agent.html × 4
-  "/claude/agent",
-  "/google/agent",
-  "/codex/agent",
-  "/copilot/agent",
-  // Phase D: long-form guides × 9
-  "/claude/skill-guide",
-  "/claude/skill-guide-intermediate",
-  "/claude/cowork-guide",
-  "/google/skill-guide",
-  "/google/skill-guide-intermediate",
-  "/google/antigravity-guide",
-  "/google/sandbox-best-practices",
-  "/codex/openai-codex-guide",
-  "/copilot/markdown-file-guide",
-  "/copilot/github-copilot",
-  // Phase E: git_worktree.html
-  "/git-worktree",
-  "/google/harness-engineering",
-  "/google/agent-harness-engineering",
-  "/google/antigravity-slash-commands-guide",
-] as const;
-
 /**
- * Generate sitemap entries from the predefined route list.
+ * Generate sitemap entries from the page registry (plans/006 §2.3 の F-1c)。
  *
- * Each sitemap item uses `SITE_URL` combined with the route path, sets `lastModified` to the current date (same value for all entries), and applies different `changeFrequency` and `priority` for the root route versus other routes.
+ * ハードコードのルート一覧は 24 件で止まり実ルート 55 と乖離していたため、
+ * lib/page-registry.ts を唯一の導出元にする。新規ページは registry 登録だけで
+ * sitemap に載る（登録漏れは tests/page-registry-coverage.test.ts が検知する）。
  *
- * @returns An array of sitemap items where each item has:
- * - `url`: `SITE_URL` concatenated with the route path
- * - `lastModified`: the current date (same for all items)
- * - `changeFrequency`: `"weekly"` for `/`, `"monthly"` for all other routes
- * - `priority`: `1.0` for `/`, `0.8` for all other routes
+ * `lastModified` にはページの `lastReviewed`（人間が内容を確認した日）を使う。
+ * ビルド日時ではなく実際の確認日を出すことで、クローラーに正しい鮮度を伝える。
+ *
+ * @returns 各エントリが url / lastModified / changeFrequency / priority を持つ sitemap 配列
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  const lastModified = new Date();
-  return ROUTES.map((route) => ({
-    url: `${SITE_URL}${route}`,
-    lastModified,
-    changeFrequency: route === "/" ? ("weekly" as const) : ("monthly" as const),
-    priority: route === "/" ? 1.0 : 0.8,
-  }));
+  return pageRegistry.map((page) => {
+    const isRoot = page.slug === "/";
+    return {
+      url: isRoot ? `${SITE_URL}/` : `${SITE_URL}${page.slug}`,
+      lastModified: page.lastReviewed,
+      changeFrequency: isRoot ? ("weekly" as const) : ("monthly" as const),
+      priority: isRoot ? 1.0 : 0.8,
+    };
+  });
 }

--- a/web-next/app/whats-new/page.module.css
+++ b/web-next/app/whats-new/page.module.css
@@ -1,0 +1,105 @@
+.main {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 5rem;
+  color: var(--txt, #eaf0f8);
+}
+
+.hero {
+  padding: 1.5rem 0 2.5rem;
+  border-bottom: 1px solid var(--brd, #182035);
+  margin-bottom: 2.5rem;
+}
+
+.h1 {
+  font-family: var(--font-syne, sans-serif);
+  font-size: clamp(1.9rem, 5vw, 2.8rem);
+  line-height: 1.2;
+  margin: 0 0 0.75rem;
+}
+
+.lead {
+  color: var(--dim, #b6caea);
+  font-size: 0.95rem;
+  line-height: 1.8;
+  margin: 0;
+  max-width: 68ch;
+}
+
+.section {
+  margin-bottom: 3.5rem;
+}
+
+.h2 {
+  font-size: 1.35rem;
+  margin: 0 0 0.4rem;
+}
+
+.sectionNote {
+  color: var(--muted, #89abde);
+  font-size: 0.8rem;
+  margin: 0 0 1.5rem;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card {
+  display: block;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--brd, #182035);
+  border-radius: 10px;
+  background: var(--srf, #0c1220);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  border-color: var(--acc, #3b82f6);
+}
+
+.cardHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.35rem;
+}
+
+.cardTitle {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.date {
+  font-family: var(--font-jetbrains-mono, monospace);
+  font-size: 0.78rem;
+  color: var(--muted, #89abde);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.group {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--brd, #182035);
+  color: var(--muted, #89abde);
+  margin-right: 0.5rem;
+}
+
+.summary {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--dim, #b6caea);
+}

--- a/web-next/app/whats-new/page.test.tsx
+++ b/web-next/app/whats-new/page.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * F-2 契約テスト: What's New ページ（plans/006 §3 Phase 1）。
+ *
+ * ページの内容は page-registry から静的生成されるため、テストも registry を
+ * 参照して「registry の中身がそのまま出ているか」を検証する（ハードコードしない）。
+ */
+import { render } from "@testing-library/react";
+import type { Metadata } from "next";
+import { describe, expect, it } from "vitest";
+import { byAddedAtDesc, byLastReviewedDesc } from "@/lib/page-registry";
+import Page, { metadata } from "./page";
+
+describe("/whats-new page", () => {
+  it("h1 に What's New が含まれる", () => {
+    const { container } = render(<Page />);
+    expect(container.querySelector("h1")?.textContent).toContain("What's New");
+  });
+
+  it("新着 / 最近更新の 2 セクションを持つ", () => {
+    const { container } = render(<Page />);
+    const sections = container.querySelectorAll("section");
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain("新着");
+    expect(container.textContent).toContain("最近更新");
+  });
+
+  it("新着セクションが addedAt 降順の先頭ページを含む", () => {
+    const newest = byAddedAtDesc(1)[0];
+    const { container } = render(<Page />);
+    const links = Array.from(container.querySelectorAll(`a[href="${newest.slug}"]`));
+    expect(links.length).toBeGreaterThan(0);
+    expect(container.textContent).toContain(newest.title);
+    expect(container.textContent).toContain(newest.summary);
+  });
+
+  it("最近更新セクションが lastReviewed 降順の先頭ページを含む", () => {
+    const freshest = byLastReviewedDesc(1)[0];
+    const { container } = render(<Page />);
+    expect(container.querySelectorAll(`a[href="${freshest.slug}"]`).length).toBeGreaterThan(0);
+  });
+
+  it("日付を機械可読な <time dateTime> で出す", () => {
+    const { container } = render(<Page />);
+    const times = Array.from(container.querySelectorAll("time"));
+    expect(times.length).toBeGreaterThan(0);
+    for (const t of times) {
+      expect(t.getAttribute("datetime")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("内部リンクが .html を含まない（clean URL）", () => {
+    const { container } = render(<Page />);
+    for (const link of Array.from(container.querySelectorAll("a[href^='/']"))) {
+      expect(link.getAttribute("href")).not.toContain(".html");
+    }
+  });
+
+  it("外部リンクがあれば rel=noopener noreferrer を持つ", () => {
+    const { container } = render(<Page />);
+    for (const link of Array.from(container.querySelectorAll("a[target='_blank']"))) {
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
+  it("metadata が export されている", () => {
+    const meta = metadata as Metadata;
+    expect(typeof meta.title).toBe("string");
+    expect(meta.title).toContain("What's New");
+    expect(typeof meta.description).toBe("string");
+  });
+});

--- a/web-next/app/whats-new/page.tsx
+++ b/web-next/app/whats-new/page.tsx
@@ -12,6 +12,13 @@ export const metadata: Metadata = {
 /** 一覧に出す件数。全 56 ページを並べても読者は読まないため上位のみ。 */
 const LIST_LIMIT = 12;
 
+/**
+ * Renders a page registry entry as a navigational card with its relevant date and summary.
+ *
+ * @param entry - The page registry entry to display
+ * @param date - The date associated with the card
+ * @param dateLabel - The label describing the date
+ */
 function PageCard({
   entry,
   date,
@@ -41,10 +48,9 @@ function PageCard({
 }
 
 /**
- * What's New — 新着・更新情報ページ（plans/006 §3 Phase 1 の F-2）。
+ * Renders the “What’s New” page with newly published and recently reviewed guides.
  *
- * 内容は lib/page-registry.ts から静的生成する。docs/PROGRESS.md（開発者向け）とは
- * 役割を分離し、本ページは読者向けの鮮度導線に徹する（006 §4）。
+ * Each section displays up to 12 entries using dates from the page registry.
  */
 export default function WhatsNewPage() {
   const newest = byAddedAtDesc(LIST_LIMIT);

--- a/web-next/app/whats-new/page.tsx
+++ b/web-next/app/whats-new/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { byAddedAtDesc, byLastReviewedDesc, type PageEntry } from "@/lib/page-registry";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = {
+  title: "What's New — 新着・更新情報 | LLM-Studies",
+  description:
+    "LLM-Studies の新着ページと最近内容を確認したページの一覧。各ガイドの公開日・最終確認日をページレジストリから自動生成しています。",
+};
+
+/** 一覧に出す件数。全 56 ページを並べても読者は読まないため上位のみ。 */
+const LIST_LIMIT = 12;
+
+function PageCard({
+  entry,
+  date,
+  dateLabel,
+}: {
+  entry: PageEntry;
+  date: string;
+  dateLabel: string;
+}) {
+  return (
+    <li>
+      <Link className={styles.card} href={entry.slug}>
+        <span className={styles.cardHead}>
+          <span className={styles.cardTitle}>
+            <span className={styles.group}>{entry.group}</span>
+            {entry.title}
+          </span>
+          <span className={styles.date}>
+            {dateLabel}
+            <time dateTime={date}> {date}</time>
+          </span>
+        </span>
+        <p className={styles.summary}>{entry.summary}</p>
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * What's New — 新着・更新情報ページ（plans/006 §3 Phase 1 の F-2）。
+ *
+ * 内容は lib/page-registry.ts から静的生成する。docs/PROGRESS.md（開発者向け）とは
+ * 役割を分離し、本ページは読者向けの鮮度導線に徹する（006 §4）。
+ */
+export default function WhatsNewPage() {
+  const newest = byAddedAtDesc(LIST_LIMIT);
+  const freshest = byLastReviewedDesc(LIST_LIMIT);
+
+  return (
+    <main className={styles.main}>
+      <header className={styles.hero}>
+        <h1 className={styles.h1}>What&apos;s New</h1>
+        <p className={styles.lead}>
+          新しく公開したガイドと、直近で内容を確認したガイドの一覧です。
+          日付はページレジストリを唯一の出典としており、各ページ上部の鮮度表示と常に一致します。
+        </p>
+      </header>
+
+      <section className={styles.section} aria-labelledby="newest">
+        <h2 className={styles.h2} id="newest">
+          新着ページ
+        </h2>
+        <p className={styles.sectionNote}>公開日（初回追加日）の新しい順・上位 {LIST_LIMIT} 件</p>
+        <ul className={styles.list}>
+          {newest.map((entry) => (
+            <PageCard key={entry.slug} entry={entry} date={entry.addedAt} dateLabel="公開" />
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.section} aria-labelledby="recently-reviewed">
+        <h2 className={styles.h2} id="recently-reviewed">
+          最近更新したページ
+        </h2>
+        <p className={styles.sectionNote}>
+          最終確認日の新しい順・上位 {LIST_LIMIT} 件。月次更新で内容を確認した日を示します
+        </p>
+        <ul className={styles.list}>
+          {freshest.map((entry) => (
+            <PageCard
+              key={entry.slug}
+              entry={entry}
+              date={entry.lastReviewed}
+              dateLabel="最終確認"
+            />
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web-next/components/site/PageFreshness.module.css
+++ b/web-next/components/site/PageFreshness.module.css
@@ -1,0 +1,42 @@
+/**
+ * 鮮度バッジ。DisclaimerBanner (position: fixed) の直下、コンテンツの先頭に
+ * 通常フローで積む。--ch-disclaimer-height の計算には影響しない。
+ */
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.5rem 1.25rem 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--muted, #89abde);
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
+}
+
+.value {
+  font-family: var(--font-jetbrains-mono, monospace);
+  color: var(--dim, #b6caea);
+  font-variant-numeric: tabular-nums;
+}
+
+.sep {
+  opacity: 0.45;
+}
+
+@media (max-width: 480px) {
+  .bar {
+    justify-content: flex-start;
+    padding: 0.4rem 1rem 0;
+    font-size: 0.7rem;
+  }
+}

--- a/web-next/components/site/PageFreshness.test.tsx
+++ b/web-next/components/site/PageFreshness.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * F-1b 契約テスト: 鮮度バッジ（最終確認日 / 公開日）。
+ *
+ * SiteHeader と同じく pathname プロップでテストから現在地を上書きできる設計を固定する。
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { findBySlug } from "@/lib/page-registry";
+import { PageFreshness } from "./PageFreshness";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+describe("PageFreshness", () => {
+  it("registry に存在するパスで最終確認日を描画する", () => {
+    const entry = findBySlug("/claude/skill");
+    expect(entry).toBeDefined();
+
+    const { container } = render(<PageFreshness pathname="/claude/skill" />);
+    expect(container.textContent).toContain(entry?.lastReviewed);
+  });
+
+  it("公開日（addedAt）も描画する", () => {
+    const entry = findBySlug("/git-worktree");
+    const { container } = render(<PageFreshness pathname="/git-worktree" />);
+    expect(container.textContent).toContain(entry?.addedAt);
+  });
+
+  it("機械可読な <time dateTime> を出力する", () => {
+    const entry = findBySlug("/claude/skill");
+    const { container } = render(<PageFreshness pathname="/claude/skill" />);
+    const times = Array.from(container.querySelectorAll("time"));
+    expect(times.length).toBeGreaterThanOrEqual(2);
+    const dateTimes = times.map((t) => t.getAttribute("datetime"));
+    expect(dateTimes).toContain(entry?.lastReviewed);
+    expect(dateTimes).toContain(entry?.addedAt);
+  });
+
+  it("registry に無いパスでは何も描画しない", () => {
+    const { container } = render(<PageFreshness pathname="/does/not/exist" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("末尾スラッシュ付きのパスでも解決する", () => {
+    const entry = findBySlug("/claude/skill");
+    const { container } = render(<PageFreshness pathname="/claude/skill/" />);
+    expect(container.textContent).toContain(entry?.lastReviewed);
+  });
+
+  it("ラベルに「最終確認」を含む（読者に鮮度の意味が伝わる）", () => {
+    const { container } = render(<PageFreshness pathname="/claude/skill" />);
+    expect(container.textContent).toContain("最終確認");
+  });
+});

--- a/web-next/components/site/PageFreshness.tsx
+++ b/web-next/components/site/PageFreshness.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { findBySlug } from "@/lib/page-registry";
+import styles from "./PageFreshness.module.css";
+
+/**
+ * 鮮度バッジ — 現在のページの最終確認日 / 公開日を表示する。
+ *
+ * plans/006 §1 の最大の負債（STATE-08: 鮮度が見えない）への対応。
+ * SiteHeader と同じく layout.tsx に 1 箇所マウントし、usePathname() で現在地を得て
+ * page-registry から引く。これにより 55 個の page.tsx を編集せずに全ページへ適用でき、
+ * 今後追加されるページも registry 登録だけで自動的に鮮度表示される。
+ *
+ * @param pathname - テストから現在地を上書きするためのプロップ（SiteHeader と同じ規約）
+ * @returns registry に登録されたページならバッジ。未登録パスでは null
+ */
+export function PageFreshness({ pathname: pathnameProp }: { pathname?: string } = {}) {
+  const fromHook = usePathname();
+  const pathname = pathnameProp ?? fromHook ?? "/";
+  const entry = findBySlug(pathname);
+
+  if (!entry) return null;
+
+  return (
+    <div className={styles.bar} lang="ja">
+      <span className={styles.item}>
+        最終確認
+        <time className={styles.value} dateTime={entry.lastReviewed}>
+          {entry.lastReviewed}
+        </time>
+      </span>
+      <span className={styles.sep} aria-hidden="true">
+        /
+      </span>
+      <span className={styles.item}>
+        公開
+        <time className={styles.value} dateTime={entry.addedAt}>
+          {entry.addedAt}
+        </time>
+      </span>
+    </div>
+  );
+}

--- a/web-next/components/site/PageFreshness.tsx
+++ b/web-next/components/site/PageFreshness.tsx
@@ -5,15 +5,10 @@ import { findBySlug } from "@/lib/page-registry";
 import styles from "./PageFreshness.module.css";
 
 /**
- * 鮮度バッジ — 現在のページの最終確認日 / 公開日を表示する。
+ * Displays the current page's last-reviewed and publication dates.
  *
- * plans/006 §1 の最大の負債（STATE-08: 鮮度が見えない）への対応。
- * SiteHeader と同じく layout.tsx に 1 箇所マウントし、usePathname() で現在地を得て
- * page-registry から引く。これにより 55 個の page.tsx を編集せずに全ページへ適用でき、
- * 今後追加されるページも registry 登録だけで自動的に鮮度表示される。
- *
- * @param pathname - テストから現在地を上書きするためのプロップ（SiteHeader と同じ規約）
- * @returns registry に登録されたページならバッジ。未登録パスでは null
+ * @param pathname - Optional route path override used to select the page metadata.
+ * @returns A freshness badge for a registered page, or `null` when no registry entry exists.
  */
 export function PageFreshness({ pathname: pathnameProp }: { pathname?: string } = {}) {
   const fromHook = usePathname();

--- a/web-next/components/site/nav-links.ts
+++ b/web-next/components/site/nav-links.ts
@@ -166,4 +166,5 @@ export const navLinks: readonly NavLink[] = [
     children: [{ name: "Evaluation & Observability", href: "/llm-ops/evaluation-observability" }],
   },
   { name: "Git Worktree", href: "/git-worktree" },
+  { name: "What's New", href: "/whats-new" },
 ];

--- a/web-next/lib/page-registry.test.ts
+++ b/web-next/lib/page-registry.test.ts
@@ -106,7 +106,7 @@ describe("byAddedAtDesc / byLastReviewedDesc", () => {
     expect(sorted).toHaveLength(pageRegistry.length);
     for (let i = 1; i < sorted.length; i++) {
       expect(
-        sorted[i - 1].lastReviewed.localeCompare(sorted[i].lastReviewed),
+        sorted[i - 1].lastReviewed.localeCompare(sorted[i].lastReviewed)
       ).toBeGreaterThanOrEqual(0);
     }
   });

--- a/web-next/lib/page-registry.test.ts
+++ b/web-next/lib/page-registry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  byAddedAtDesc,
+  byLastReviewedDesc,
+  findBySlug,
+  PageEntrySchema,
+  pageRegistry,
+} from "@/lib/page-registry";
+
+describe("PageEntrySchema", () => {
+  const valid = {
+    slug: "/claude/skill",
+    title: "Skill",
+    group: "Providers",
+    provider: "claude",
+    topics: ["skill"],
+    summary: "テスト用の要約。",
+    addedAt: "2026-04-18",
+    lastReviewed: "2026-07-01",
+  };
+
+  it("正当なエントリを受理する", () => {
+    expect(() => PageEntrySchema.parse(valid)).not.toThrow();
+  });
+
+  it("provider は省略可能", () => {
+    const { provider: _provider, ...rest } = valid;
+    expect(() => PageEntrySchema.parse(rest)).not.toThrow();
+  });
+
+  it("空 slug を拒否する", () => {
+    expect(() => PageEntrySchema.parse({ ...valid, slug: "" })).toThrow();
+  });
+
+  it("/ で始まらない slug を拒否する", () => {
+    expect(() => PageEntrySchema.parse({ ...valid, slug: "claude/skill" })).toThrow();
+  });
+
+  it("YYYY-MM-DD でない日付を拒否する", () => {
+    expect(() => PageEntrySchema.parse({ ...valid, lastReviewed: "2026/07/01" })).toThrow();
+    expect(() => PageEntrySchema.parse({ ...valid, addedAt: "2026-7-1" })).toThrow();
+  });
+
+  it("空タイトルを拒否する", () => {
+    expect(() => PageEntrySchema.parse({ ...valid, title: "" })).toThrow();
+  });
+});
+
+describe("pageRegistry", () => {
+  it("Home（/）を含む", () => {
+    expect(pageRegistry.some((e) => e.slug === "/")).toBe(true);
+  });
+
+  it("全エントリがスキーマを満たす", () => {
+    for (const entry of pageRegistry) {
+      expect(() => PageEntrySchema.parse(entry)).not.toThrow();
+    }
+  });
+
+  it("slug が重複しない", () => {
+    const slugs = pageRegistry.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("addedAt <= lastReviewed（不変条件）", () => {
+    for (const entry of pageRegistry) {
+      expect(entry.addedAt.localeCompare(entry.lastReviewed)).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("provider は既知のプロバイダーのみ", () => {
+    const known = ["claude", "google", "codex", "copilot"];
+    for (const entry of pageRegistry) {
+      if (entry.provider) expect(known).toContain(entry.provider);
+    }
+  });
+});
+
+describe("findBySlug", () => {
+  it("既知の slug でエントリを返す", () => {
+    const entry = findBySlug("/claude/skill");
+    expect(entry?.slug).toBe("/claude/skill");
+    expect(entry?.provider).toBe("claude");
+  });
+
+  it("未知の slug では undefined を返す", () => {
+    expect(findBySlug("/does/not/exist")).toBeUndefined();
+  });
+
+  it("末尾スラッシュを正規化して解決する", () => {
+    expect(findBySlug("/claude/skill/")?.slug).toBe("/claude/skill");
+  });
+});
+
+describe("byAddedAtDesc / byLastReviewedDesc", () => {
+  it("byAddedAtDesc は addedAt の降順で全件返す", () => {
+    const sorted = byAddedAtDesc();
+    expect(sorted).toHaveLength(pageRegistry.length);
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i - 1].addedAt.localeCompare(sorted[i].addedAt)).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("byLastReviewedDesc は lastReviewed の降順で全件返す", () => {
+    const sorted = byLastReviewedDesc();
+    expect(sorted).toHaveLength(pageRegistry.length);
+    for (let i = 1; i < sorted.length; i++) {
+      expect(
+        sorted[i - 1].lastReviewed.localeCompare(sorted[i].lastReviewed),
+      ).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("limit を指定すると件数を絞る", () => {
+    expect(byAddedAtDesc(5)).toHaveLength(5);
+    expect(byLastReviewedDesc(3)).toHaveLength(3);
+  });
+
+  it("元の pageRegistry を破壊しない", () => {
+    const before = pageRegistry.map((e) => e.slug);
+    byAddedAtDesc();
+    byLastReviewedDesc();
+    expect(pageRegistry.map((e) => e.slug)).toEqual(before);
+  });
+});

--- a/web-next/lib/page-registry.ts
+++ b/web-next/lib/page-registry.ts
@@ -655,10 +655,10 @@ export const pageRegistry: readonly PageEntry[] = entries.map((e) => PageEntrySc
 const bySlug = new Map(pageRegistry.map((e) => [e.slug, e]));
 
 /**
- * slug（ルートパス）からエントリを引く。末尾スラッシュは正規化する。
+ * Finds a page entry by its slug, ignoring trailing slashes.
  *
- * @param slug - 検索対象のルートパス（例: "/claude/skill"）
- * @returns 一致するエントリ。未登録なら undefined
+ * @param slug - The slug to search for, such as `/claude/skill`
+ * @returns The matching page entry, or `undefined` if none is registered
  */
 export function findBySlug(slug: string): PageEntry | undefined {
   let normalized = slug;
@@ -669,9 +669,10 @@ export function findBySlug(slug: string): PageEntry | undefined {
 }
 
 /**
- * 公開日（addedAt）の降順に並べる。What's New の「新着」セクション用。
+ * Lists page entries from newest to oldest by addition date.
  *
- * @param limit - 返す最大件数。省略時は全件
+ * @param limit - Maximum number of entries to return; when omitted, returns all entries.
+ * @returns Page entries ordered by descending `addedAt` date.
  */
 export function byAddedAtDesc(limit?: number): PageEntry[] {
   const sorted = [...pageRegistry].sort((a, b) => b.addedAt.localeCompare(a.addedAt));
@@ -679,9 +680,10 @@ export function byAddedAtDesc(limit?: number): PageEntry[] {
 }
 
 /**
- * 最終確認日（lastReviewed）の降順に並べる。What's New の「最近更新」セクション用。
+ * Lists pages ordered by most recent review date.
  *
- * @param limit - 返す最大件数。省略時は全件
+ * @param limit - Maximum number of pages to return; returns all pages when omitted.
+ * @returns Pages sorted by `lastReviewed` in descending order.
  */
 export function byLastReviewedDesc(limit?: number): PageEntry[] {
   const sorted = [...pageRegistry].sort((a, b) => b.lastReviewed.localeCompare(a.lastReviewed));

--- a/web-next/lib/page-registry.ts
+++ b/web-next/lib/page-registry.ts
@@ -1,0 +1,675 @@
+/**
+ * ページレジストリ — 全ページのメタデータの Single Source of Truth。
+ *
+ * plans/006-platform-roadmap-v2.md §2.3 (F-1) に基づく。鮮度表示 (PageFreshness)・
+ * What's New・sitemap はすべて本ファイルから導出し、属性の複製先を増やさない。
+ *
+ * 設計判断:
+ * - nav-links.ts の Zod 検証パターンを踏襲し、モジュール評価時に parse して
+ *   不正データをビルド時に落とす（実行時に壊れたページを配信しない）。
+ * - `lastReviewed` は「人間が内容を確認した日」。初期値は各 page.tsx の最終コミット日を
+ *   機械採取した値で、以降は monthly-update スキルの月次確認が当日日付へ書き戻す。
+ * - `group` は 006 §2.2 の 8 グループ体系。ナビの再グルーピング (F-4') で参照するが、
+ *   現時点では表示に影響しない。
+ * - `addedAt` は git の初回追加日（`--diff-filter=A --follow`）。What's New の「新着」順に使う。
+ *
+ * 新規ページを追加したら必ず本レジストリにも登録すること。
+ * tests/page-registry-coverage.test.ts が登録漏れを機械検知する。
+ */
+
+import { z } from "zod";
+
+/** YYYY-MM-DD 形式のみ許可（localeCompare による日付比較が成立する前提を守る） */
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD");
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .refine((s) => s.startsWith("/"), "slug must start with /");
+
+export const PageEntrySchema = z.object({
+  /** ルートパス。Home は "/"。末尾スラッシュなし。 */
+  slug: slugSchema,
+  /** ナビ表示名（nav-links.ts と同じ短いラベル） */
+  title: z.string().min(1),
+  /** 006 §2.2 の再グルーピング体系 */
+  group: z.string().min(1),
+  /** プロバイダー系ページのみ */
+  provider: z.enum(["claude", "google", "codex", "copilot"]).optional(),
+  /** 横断検索・関連リンク (F-5 / F-7) 用のトピックタグ */
+  topics: z.array(z.string()),
+  /** 一覧・What's New に出す 1〜2 文の要約 */
+  summary: z.string().min(1),
+  /** 公開日（git の初回追加日） */
+  addedAt: isoDateSchema,
+  /** 最終確認日（人間が内容を確認した日） */
+  lastReviewed: isoDateSchema,
+});
+
+export type PageEntry = z.infer<typeof PageEntrySchema>;
+
+const entries: PageEntry[] = [
+  {
+    slug: "/",
+    title: "Home",
+    group: "Home",
+    topics: [],
+    summary:
+      "AI モデルの API 料金とコーディングツールのサブスク料金を時間別に比較するコスト計算機。",
+    addedAt: "2026-04-11",
+    lastReviewed: "2026-04-13",
+  },
+  {
+    slug: "/agent/context-engineering-best-practices",
+    title: "Context Engineering",
+    group: "Agent 開発",
+    topics: ["agent", "context-engineering"],
+    summary:
+      "プロンプト単体の最適化ではなく、システムプロンプト、ツール定義、履歴、外部データ、メモリ等を含むコンテキスト全体を設計・キュレーションするコンテキストエンジニアリングの実践ガイド。",
+    addedAt: "2026-07-11",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/agent/hermes-agent-advanced-guide",
+    title: "Advanced Guide",
+    group: "Agent 開発",
+    topics: ["agent", "guide"],
+    summary: "内部アーキテクチャ / 7層セキュリティ / 本番デプロイメントベストプラクティス",
+    addedAt: "2026-06-04",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/agent/loop-engineering",
+    title: "Loop Engineering Guide",
+    group: "Agent 開発",
+    topics: ["agent", "loop"],
+    summary:
+      "Boris Cherny氏（Claude Code開発者）、Peter Steinberger氏（OpenClaw開発者）、Andrew Ng氏らの発言をもとに、AIエージェントを自律的に反復させる「Loop Engineering」を初学者向けにステップバイステップで解説します。",
+    addedAt: "2026-07-05",
+    lastReviewed: "2026-07-05",
+  },
+  {
+    slug: "/agent/openclaw-advanced-agent-security-guide",
+    title: "OpenClaw Security Guide",
+    group: "Agent 開発",
+    topics: ["agent", "security", "guide"],
+    summary:
+      "OpenClaw Agent の内部構造からサブエージェント、プラグインフック、MITRE ATLAS脅威モデル、サンドボックス設定、セキュリティ監査、インシデントレスポンスまで、本番運用を見据えた高度な活用法を解説する詳細ガイド。",
+    addedAt: "2026-06-05",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/agent/skills",
+    title: "Agent Skills Guide",
+    group: "Agent 開発",
+    topics: ["skill", "agent"],
+    summary:
+      "Agent Skillsの仕組みと使い方を、Kaggle Whitepaperとagentskills.io、Anthropic公式ドキュメントをもとに初学者向けにステップバイステップで解説するガイドです。",
+    addedAt: "2026-07-05",
+    lastReviewed: "2026-07-05",
+  },
+  {
+    slug: "/ci-cd/ai-cicd-automation-best-practices",
+    title: "AI CI/CD Automation",
+    group: "開発プロセス",
+    topics: ["ci-cd"],
+    summary:
+      "機械学習(MLOps)・生成AI(LLMOps)・AIエージェントを活用した、AIシステムのCI/CD自動化プロセスを学ぶ初学者のためのステップバイステップ実践入門。",
+    addedAt: "2026-07-11",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/claude/agent",
+    title: "Agent",
+    group: "Providers",
+    provider: "claude",
+    topics: ["agent"],
+    summary:
+      "Claude Code v2.1.196 のサブエージェント / Agent Teams 開発で必要な CLAUDE.md・エージェント定義・MEMORY.md・README.md の役割と書き方を体系化したガイド。",
+    addedAt: "2026-04-19",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/code-slash-commands",
+    title: "Code Slash Commands",
+    group: "Providers",
+    provider: "claude",
+    topics: ["claude"],
+    summary:
+      "Claude Code セッションを制御するためのショートカット（スラッシュコマンド）を網羅した完全ガイド。セッション管理からモデル設定、実践ワークフローまでを解説。",
+    addedAt: "2026-05-31",
+    lastReviewed: "2026-05-31",
+  },
+  {
+    slug: "/claude/cowork-guide",
+    title: "Cowork Guide",
+    group: "Providers",
+    provider: "claude",
+    topics: ["guide"],
+    summary:
+      "コードを一行も書かずに自然言語の指示だけでファイル管理・タスク自動化を実現する Anthropic のデスクトップツール「Cowork」を初学者向けにゼロから解説します。",
+    addedAt: "2026-05-03",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/fable-5-best-practices",
+    title: "Fable 5 Best Practices",
+    group: "Providers",
+    provider: "claude",
+    topics: ["claude"],
+    summary:
+      "Claude Codeエンジニアのための中級〜上級者向けベストプラクティス。「指示を積み上げる」から「ゴールと検証基準を渡して任せる」へ ― Fable 5に最適化された思考法をステップバイステップで解説します。",
+    addedAt: "2026-07-05",
+    lastReviewed: "2026-07-05",
+  },
+  {
+    slug: "/claude/harness-engineering",
+    title: "Harness Engineering",
+    group: "Providers",
+    provider: "claude",
+    topics: ["harness"],
+    summary: "AIエージェントが安定して動作するための「環境設計（ハーネス）」完全ガイド。",
+    addedAt: "2026-05-28",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/managed-agents",
+    title: "Managed Agents",
+    group: "Providers",
+    provider: "claude",
+    topics: ["agent"],
+    summary:
+      "初学者でもわかるステップバイステップ解説。エージェントの作成から本番運用まで、ベストプラクティスを網羅します。",
+    addedAt: "2026-05-31",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/self-hosted-sandboxes",
+    title: "Self-hosted Sandboxes",
+    group: "Providers",
+    provider: "claude",
+    topics: ["sandbox"],
+    summary:
+      "AIエージェントのツール実行環境を自社インフラに移動する方法を、初学者から実務者まで使えるようにステップバイステップで解説します。",
+    addedAt: "2026-06-11",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/claude/skill",
+    title: "Skill",
+    group: "Providers",
+    provider: "claude",
+    topics: ["skill"],
+    summary:
+      "CLAUDE.md / spec.md / requirements.md / design.md / tasks.md / MEMORY.md / SKILL.md など、Claude Code の仕様駆動開発 (SDD) を支えるマークダウンファイル群の役割・構造・ベストプラクティスを公式根拠付きで解説。",
+    addedAt: "2026-04-18",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/claude/skill-guide",
+    title: "Skill Guide",
+    group: "Providers",
+    provider: "claude",
+    topics: ["skill", "guide"],
+    summary:
+      "Claude Code に「専門的なスキル」を追加するための設定ファイル SKILL.md の概念・構造・活用方法を理解するための初学者向け完全ガイドです。",
+    addedAt: "2026-05-01",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/skill-guide-intermediate",
+    title: "Skill Guide (中級)",
+    group: "Providers",
+    provider: "claude",
+    topics: ["skill", "guide"],
+    summary:
+      "プログレッシブ・ディスクロージャー、トークン経済、動的コンテキスト注入、context:fork、エンタープライズプロビジョニングまで網羅した実践リファレンスです。",
+    addedAt: "2026-05-02",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/claude/skills-sh",
+    title: "skills.sh Guide",
+    group: "Agent 開発",
+    provider: "claude",
+    topics: ["skill"],
+    summary:
+      "skills.shの仕組み、CLIの使い方、主要スキルの利用方法を初学者向けにステップバイステップで解説する技術ガイド",
+    addedAt: "2026-07-05",
+    lastReviewed: "2026-07-05",
+  },
+  {
+    slug: "/code-review/coderabbit-guide",
+    title: "CodeRabbit Guide",
+    group: "開発プロセス",
+    topics: ["code-review", "review", "guide"],
+    summary: "AI コードレビューツール CodeRabbit の導入・設定・運用を解説する実践ガイド。",
+    addedAt: "2026-06-01",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/code-review/copilot-code-review",
+    title: "Copilot Code Review",
+    group: "開発プロセス",
+    topics: ["code-review", "review"],
+    summary:
+      "AI駆動のコードレビューをチーム開発に深く組み込む——概念・設定・運用まで中〜上級者向けにステップバイステップで解説",
+    addedAt: "2026-06-01",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/code-review/sonar-qube",
+    title: "SonarQube Guide",
+    group: "開発プロセス",
+    topics: ["code-review", "review"],
+    summary:
+      "SonarQube による静的解析とコード品質ゲートの実践ガイド。CI 連携とカバレッジ計測を解説。",
+    addedAt: "2026-06-01",
+    lastReviewed: "2026-06-30",
+  },
+  {
+    slug: "/code-review/tool-pricing",
+    title: "Tool Pricing",
+    group: "開発プロセス",
+    topics: ["code-review", "pricing", "review"],
+    summary:
+      "GitHub Copilot・Codex・Claude・CodeRabbit・SonarQube など Code Review 系 AI ツール 9 種の料金目安・主用途・メリット/デメリットを、価格の出典付きで横断比較。",
+    addedAt: "2026-06-03",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/codex/agent",
+    title: "Agent",
+    group: "Providers",
+    provider: "codex",
+    topics: ["agent"],
+    summary:
+      "OpenAI Codex CLI (v0.142.4, 2026-06-29 最新版) および Agents SDK を使ったサブエージェント / マルチエージェント開発で必要な AGENTS.md・AGENTS.override.md・SKILL.md・config.toml の役割と書き方を体系化したガイド。初学者向け 7 ステップ入門から PM 駆動 SDD パターンまで網羅。GPT-5.5 / GPT-5-Codex 対応、Codex Remote GA。",
+    addedAt: "2026-04-26",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/codex/harness-engineering",
+    title: "Harness Engineering",
+    group: "Providers",
+    provider: "codex",
+    topics: ["harness"],
+    summary:
+      "OpenAI Codex のハーネスエンジニアリング完全ガイド。エージェント実行環境の設計と運用。",
+    addedAt: "2026-05-29",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/codex/openai-codex-guide",
+    title: "Codex Guide",
+    group: "Providers",
+    provider: "codex",
+    topics: ["guide"],
+    summary:
+      "2026-06-29 最新版 (v0.142.4)。初学者から中級者まで、GPT-5.5 / GPT-5-Codex を搭載した AI コーディングエージェントを最大限に活かすベストプラクティスをステップバイステップで解説します（Codex Remote GA 対応）。",
+    addedAt: "2026-05-08",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/codex/skill",
+    title: "Skill",
+    group: "Providers",
+    provider: "codex",
+    topics: ["skill"],
+    summary:
+      "AGENTS.md / SKILL.md / .prompt.md / REQUIREMENTS.md / AGENT_TASKS.md — OpenAI Codex 最新 (2026年最新版) の AI 仕様駆動開発を支える全マークダウンファイルの役割・構造・ベストプラクティスを公式根拠付きで解説 (v0.142.4, GPT-5.5 / GPT-5-Codex 対応、Codex Remote GA)。",
+    addedAt: "2026-04-18",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/copilot/agent",
+    title: "Agent",
+    group: "Providers",
+    provider: "copilot",
+    topics: ["agent"],
+    summary:
+      "GitHub Copilot .agent.md の完全ベストプラクティスガイド。フロントマター全仕様・ステップバイステップ作成・Handoffs（エージェント連鎖）・Subagents（サブエージェント）・MCP統合・マルチエージェント設計パターン・トラブルシューティングを 2026年6月最新版の公式ドキュメント準拠で解説。Cloud agent GA・組織/エンタープライズエージェント（JetBrains）・Copilot code review の AGENTS.md 対応に対応。",
+    addedAt: "2026-04-27",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/copilot/github-copilot",
+    title: "GitHub Copilot",
+    group: "Providers",
+    provider: "copilot",
+    topics: ["copilot"],
+    summary:
+      "2026年6月最新版 — 初学者からエキスパートまで対応したステップバイステップのAIコーディングアシスタント活用法。Cloud agent GA・従量課金（AI Credits）・Copilot code review の AGENTS.md 対応を反映。",
+    addedAt: "2026-05-08",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/copilot/markdown-file-guide",
+    title: "Markdown Guide",
+    group: "Providers",
+    provider: "copilot",
+    topics: ["guide"],
+    summary:
+      "copilot-instructions.md / .instructions.md / .prompt.md / .chatmode.md / .agent.md / AGENTS.md / SKILL.md / MCP / Plan Mode — Copilotの全カスタマイズファイル・新機能を根拠ソース付きで徹底解説。Copilot code review の AGENTS.md 対応（2026-06-18）・Cloud agent GA を反映。",
+    addedAt: "2026-05-08",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/copilot/skill",
+    title: "Skill",
+    group: "Providers",
+    provider: "copilot",
+    topics: ["skill"],
+    summary:
+      "GitHub Copilot Coding Agent / VS Code Agent Mode / Copilot CLI 対応の SKILL.md ガイド。フロントマター完全仕様・Progressive Disclosure 3段階ローディング・ステップバイステップ作成・実践テンプレート集・トラブルシューティングを 2026年6月最新版の公式ドキュメント根拠付きで徹底解説。Copilot code review は AGENTS.md 対応（2026-06-18）、Cloud agent は GA。",
+    addedAt: "2026-04-18",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/cursor/complete-guide",
+    title: "Cursor Guide",
+    group: "開発プロセス",
+    topics: ["cursor", "guide"],
+    summary:
+      "初学者のためのCursor完全ガイド。AIオートコンプリート(Tab補完)、自律Agentモード、コンテキスト管理(@ Symbols)、カスタムルール/サブエージェント設定、MCP連携等の使い方とベストプラクティスを解説。",
+    addedAt: "2026-07-04",
+    lastReviewed: "2026-07-04",
+  },
+  {
+    slug: "/cursor/complete-guide-intermediate",
+    title: "Cursor Guide (中級)",
+    group: "開発プロセス",
+    topics: ["cursor", "guide"],
+    summary:
+      "中〜上級者のためのCursor実践ガイド。アーキテクチャ全体像、Tab補完、インライン編集、Plan Mode、Debug Mode、MCP、Agent Skills、Subagents、Hooks等の各機能の仕組みとベストプラクティスを解説。",
+    addedAt: "2026-07-05",
+    lastReviewed: "2026-07-05",
+  },
+  {
+    slug: "/git-worktree",
+    title: "Git Worktree",
+    group: "開発プロセス",
+    topics: ["worktree"],
+    summary:
+      "Claude / Gemini / Codex / GitHub Copilot — 4プラットフォームのドキュメントをAIツールとWebSearchで並列更新するための完全ガイド。git worktreeのセットアップから日常ワークフロー・GitHub Actions統合まで。",
+    addedAt: "2026-05-08",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/adk-best-practices",
+    title: "ADK Best Practices",
+    group: "Providers",
+    provider: "google",
+    topics: ["google"],
+    summary:
+      "Google Agent Development Kit (ADK) を用いた、マルチエージェント設計、状態管理、コンテキスト最適化、コールバック、評価、可観測性、デプロイメントのステップバイステップ実践ガイド。",
+    addedAt: "2026-07-11",
+    lastReviewed: "2026-07-13",
+  },
+  {
+    slug: "/google/agent",
+    title: "Agent",
+    group: "Providers",
+    provider: "google",
+    topics: ["agent"],
+    summary:
+      "最新の Google Gemini CLI / Antigravity CLI (as of 2026-06)・最新の ADK (as of 2026-06)・最新のエージェント連携プロトコル (A2A/AP2/A2UI等) 時代のサブエージェント / マルチエージェント開発で必要な GEMINI.md・AGENTS.md・agent.py・agent.json・.geminiignore・settings.json の役割と書き方を体系化したガイド。Gemini CLI は 2026-06-18 に AI Pro/Ultra/無料 Code Assist 向けサンセット済（→ Antigravity CLI へ移行）。",
+    addedAt: "2026-04-24",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/agent-harness-engineering",
+    title: "Agent Harness Engineering",
+    group: "Providers",
+    provider: "google",
+    topics: ["agent", "harness"],
+    summary:
+      "Google ADKとGeminiを組み合わせたAIエージェント評価ハーネスの設計思想、実装パターン、テストダブル、LLM-as-Judge、CI統合のベストプラクティスを解説する完全ガイドです。",
+    addedAt: "2026-05-30",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/antigravity-guide",
+    title: "Antigravity",
+    group: "Providers",
+    provider: "google",
+    topics: ["guide"],
+    summary:
+      "GEMINI.md から SKILL.md・Rules・Workflows・Artifacts まで、Google Antigravity エコシステムの全体を根拠ソース付きで徹底解説。初学者でもステップバイステップで理解できるベストプラクティス完全ガイド。Antigravity 2.0 (2026-05-19, Google I/O 2026) — Antigravity CLI / SDK / Managed Agents / plugins / Gemini 3.5 Flash 対応。",
+    addedAt: "2026-05-08",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/antigravity-slash-commands-guide",
+    title: "Antigravity Slash Commands",
+    group: "Providers",
+    provider: "google",
+    topics: ["guide"],
+    summary:
+      "Gemini CLI / Antigravity CLI の全コマンドをステップバイステップで解説。初学者がゼロから実践できるベストプラクティス付き。",
+    addedAt: "2026-06-02",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/harness-engineering",
+    title: "Harness Engineering",
+    group: "Providers",
+    provider: "google",
+    topics: ["harness"],
+    summary: "Googleが実践するテストハーネス設計の技術とベストプラクティスを解説する完全ガイドです。",
+    addedAt: "2026-05-28",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/notebook-lm",
+    title: "NotebookLM Guide",
+    group: "Providers",
+    provider: "google",
+    topics: ["google"],
+    summary:
+      "Google NotebookLM を実務や研究で使いこなすための中〜上級者向け完全ガイド。アーキテクチャの理解からソース設計、カスタムインストラクション、Studio活用、Gemini連携、セキュリティ・Enterprise導入、トラブルシューティングまで網羅。",
+    addedAt: "2026-07-10",
+    lastReviewed: "2026-07-11",
+  },
+  {
+    slug: "/google/sandbox-best-practices",
+    title: "Google Sandbox",
+    group: "Providers",
+    provider: "google",
+    topics: ["sandbox"],
+    summary:
+      "AIエージェント・API・コンテナ・C/C++・ブラウザ、それぞれの領域で Google が推奨する安全なサンドボックス技術（実行の箱）を、初学者でも理解できるよう図解とステップで解説します。",
+    addedAt: "2026-06-12",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/skill",
+    title: "Skill",
+    group: "Providers",
+    provider: "google",
+    topics: ["skill"],
+    summary:
+      "GEMINI.md / Rules / SKILL.md / Workflows / Knowledge Base / Artifacts / SDD仕様書群 — Google Antigravity の AI 仕様駆動開発を支えるマークダウンファイル群の役割・構造・ベストプラクティスを公式根拠付きで解説。Antigravity v2.0.1 (2026-05-23, 最新の安定化リリース) / Gemini 3.5 Flash 対応。Gemini CLI は 2026-06-18 に AI Pro/Ultra/無料 Code Assist 向けサンセット済（→ Antigravity CLI へ移行）。",
+    addedAt: "2026-04-18",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/skill-guide",
+    title: "Skill Guide",
+    group: "Providers",
+    provider: "google",
+    topics: ["skill", "guide"],
+    summary:
+      "AIエージェントに「専門知識の教科書」を渡す仕組み — SKILL.md の構造・書き方・インストール手順を Gemini CLI v0.43.0 (最終版) & Antigravity v2.0.1 対応版で完全解説。Google I/O 2026 発表内容対応。Gemini CLI は 2026-06-18 に AI Pro/Ultra/無料 Code Assist 向けサンセット済（→ Antigravity CLI へ移行）。",
+    addedAt: "2026-05-07",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/skill-guide-intermediate",
+    title: "Skill Guide (中級)",
+    group: "Providers",
+    provider: "google",
+    topics: ["skill", "guide"],
+    summary:
+      "Google Gemini CLI (v0.43.0 最終版)・Antigravity IDE (v2.0.1) における SKILL.md の設計思想、アーキテクチャ、実装パターン、運用まで。エージェント駆動開発を次のレベルに引き上げるすべての知識を網羅する。Gemini CLI は 2026-06-18 に AI Pro/Ultra/無料 Code Assist 向けサンセット済（→ Antigravity CLI へ移行）。",
+    addedAt: "2026-05-07",
+    lastReviewed: "2026-07-01",
+  },
+  {
+    slug: "/google/stitch-guide",
+    title: "Stitch Guide",
+    group: "Providers",
+    provider: "google",
+    topics: ["guide"],
+    summary:
+      "Google Labsが提供する無料のAIデザインツール「Google Stitch」の実践ガイド。Vibe Design、無限キャンバス、DESIGN.mdによるデザインシステム管理、MCP・SDK統合、プロンプト設計などのベストプラクティスを解説。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/llm-ops/evaluation-observability",
+    title: "Evaluation & Observability",
+    group: "運用・品質",
+    topics: ["llm-ops"],
+    summary:
+      "LLMアプリケーションの品質評価(Evaluation)、公開ベンチマーク(Benchmarking)の読み方、そして本番環境でのオブザーバビリティ(Observability)を体系的に学びたいエンジニア向けのベストプラクティスガイド。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/local-llm/best-practices",
+    title: "Self-hosting Best Practices",
+    group: "モデル・データ",
+    topics: ["local-llm"],
+    summary:
+      "モデル選定から量子化、推論エンジン、ハードウェア設計、セキュリティ、RAG、ファインチューニング、可観測性、デプロイ運用まで——中級〜上級エンジニアが自前のLLM基盤を安全かつ継続可能な形で運用するための、一気通貫の実践リファレンス。",
+    addedAt: "2026-07-11",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/local-llm/self-hosting",
+    title: "Self-hosting Guide",
+    group: "モデル・データ",
+    topics: ["local-llm"],
+    summary:
+      "クラウドAPIを使わず、自分のPCやサーバーでLLMを動かすための実践ガイド。ハードウェア選定、モデル選定、推論エンジン(Ollama/vLLM)、Web UI、RAG構築、本番運用、セキュリティ対策までステップバイステップで解説します。",
+    addedAt: "2026-07-10",
+    lastReviewed: "2026-07-11",
+  },
+  {
+    slug: "/mcp/mcp-best-practices",
+    title: "MCP Best Practices",
+    group: "Agent 開発",
+    topics: ["mcp"],
+    summary:
+      "Model Context Protocol (MCP) のアーキテクチャ基礎からツール設計、セキュリティ、本番運用まで、一次情報に基づいて解説する初学者向けステップバイステップ・ベストプラクティスガイド。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-13",
+  },
+  {
+    slug: "/mcp/mcp-best-practices-intermediate",
+    title: "MCP Best Practices (中級)",
+    group: "Agent 開発",
+    topics: ["mcp"],
+    summary:
+      "Model Context Protocol (MCP) の詳細なアーキテクチャ、バージョン管理、トランスポート、セキュリティ、認証・認可から運用プラクティスまで網羅的に解説するベストプラクティスガイド。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-13",
+  },
+  {
+    slug: "/multimodal/generation-best-practices",
+    title: "Generation Best Practices",
+    group: "モデル・データ",
+    topics: ["multimodal"],
+    summary:
+      "これから画像・音声生成AIを学ぶ初学者を対象に、再現可能な手順、モデル横断の普遍原則とモデル固有のコツ、安全性と法令遵守を解説するベストプラクティスガイド。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-13",
+  },
+  {
+    slug: "/multimodal/image-audio-best-practices-2026",
+    title: "Image & Audio (2026)",
+    group: "モデル・データ",
+    topics: ["multimodal"],
+    summary:
+      "拡散モデルの内部構造からモデル選定、プロンプト設計、ControlNet/LoRAによる制御、リアルタイム音声対話エージェント、コンテンツ来歴・法規制、プロダクション運用まで。中級〜上級のAIエンジニア向けに、意思決定に使える粒度でステップバイステップに解説します。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/rag/embeddings-best-practices",
+    title: "RAG & Embeddings",
+    group: "モデル・データ",
+    topics: ["rag"],
+    summary:
+      "RAG (検索拡張生成) と Embedding (埋め込み) についてゼロから実務レベルまで理解できるように、チャンキング、モデル選定、ベクトルDB、検索最適化、本番運用、評価方法などを体系的に解説する完全ガイド。",
+    addedAt: "2026-07-12",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/security/ai-security-best-practices",
+    title: "AI Security Best Practices",
+    group: "運用・品質",
+    topics: ["security"],
+    summary:
+      "初学者のためのステップバイステップ解説。OWASP・MITRE ATLAS・NIST・Google SAIF・EU AI Actなど業界標準フレームワークに基づき、LLMアプリケーションとAIエージェントのセキュリティを体系的に解説します。",
+    addedAt: "2026-07-09",
+    lastReviewed: "2026-07-11",
+  },
+  {
+    slug: "/security/ai-security-best-practices-intermediate",
+    title: "AI Security Best Practices (中級)",
+    group: "運用・品質",
+    topics: ["security"],
+    summary:
+      "LLM・RAG基盤・AIエージェント・MCP(Model Context Protocol)連携システムを設計/実装/運用するエンジニアのための、2026年7月時点の最新フレームワークと実践的な多層防御の設計指針。",
+    addedAt: "2026-07-11",
+    lastReviewed: "2026-07-12",
+  },
+  {
+    slug: "/vercel/sandbox",
+    title: "Vercel Sandbox",
+    group: "Agent 開発",
+    topics: ["sandbox"],
+    summary:
+      "信頼できないコードをミリ秒単位で安全に実行できる Linux マイクロVM。初学者でもわかるステップバイステップ解説＋ベストプラクティス付き。",
+    addedAt: "2026-06-16",
+    lastReviewed: "2026-07-01",
+  },
+];
+
+/** ビルド時検証: 不正なエントリはここで例外になり、壊れたデータのまま配信されない。 */
+export const pageRegistry: readonly PageEntry[] = entries.map((e) => PageEntrySchema.parse(e));
+
+const bySlug = new Map(pageRegistry.map((e) => [e.slug, e]));
+
+/**
+ * slug（ルートパス）からエントリを引く。末尾スラッシュは正規化する。
+ *
+ * @param slug - 検索対象のルートパス（例: "/claude/skill"）
+ * @returns 一致するエントリ。未登録なら undefined
+ */
+export function findBySlug(slug: string): PageEntry | undefined {
+  const normalized = slug.length > 1 ? slug.replace(/\/+$/, "") : slug;
+  return bySlug.get(normalized);
+}
+
+/**
+ * 公開日（addedAt）の降順に並べる。What's New の「新着」セクション用。
+ *
+ * @param limit - 返す最大件数。省略時は全件
+ */
+export function byAddedAtDesc(limit?: number): PageEntry[] {
+  const sorted = [...pageRegistry].sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+  return limit === undefined ? sorted : sorted.slice(0, limit);
+}
+
+/**
+ * 最終確認日（lastReviewed）の降順に並べる。What's New の「最近更新」セクション用。
+ *
+ * @param limit - 返す最大件数。省略時は全件
+ */
+export function byLastReviewedDesc(limit?: number): PageEntry[] {
+  const sorted = [...pageRegistry].sort((a, b) => b.lastReviewed.localeCompare(a.lastReviewed));
+  return limit === undefined ? sorted : sorted.slice(0, limit);
+}

--- a/web-next/lib/page-registry.ts
+++ b/web-next/lib/page-registry.ts
@@ -456,7 +456,8 @@ const entries: PageEntry[] = [
     group: "Providers",
     provider: "google",
     topics: ["harness"],
-    summary: "Googleが実践するテストハーネス設計の技術とベストプラクティスを解説する完全ガイドです。",
+    summary:
+      "Googleが実践するテストハーネス設計の技術とベストプラクティスを解説する完全ガイドです。",
     addedAt: "2026-05-28",
     lastReviewed: "2026-07-01",
   },
@@ -627,6 +628,16 @@ const entries: PageEntry[] = [
     lastReviewed: "2026-07-12",
   },
   {
+    slug: "/whats-new",
+    title: "What's New",
+    group: "What's New",
+    topics: [],
+    summary:
+      "新しく公開したガイドと、直近で内容を確認したガイドの一覧。ページレジストリから静的生成。",
+    addedAt: "2026-07-13",
+    lastReviewed: "2026-07-13",
+  },
+  {
     slug: "/vercel/sandbox",
     title: "Vercel Sandbox",
     group: "Agent 開発",
@@ -650,7 +661,10 @@ const bySlug = new Map(pageRegistry.map((e) => [e.slug, e]));
  * @returns 一致するエントリ。未登録なら undefined
  */
 export function findBySlug(slug: string): PageEntry | undefined {
-  const normalized = slug.length > 1 ? slug.replace(/\/+$/, "") : slug;
+  let normalized = slug;
+  while (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
   return bySlug.get(normalized);
 }
 

--- a/web-next/tests/page-registry-coverage.test.ts
+++ b/web-next/tests/page-registry-coverage.test.ts
@@ -7,11 +7,10 @@
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { pageRegistry } from "@/lib/page-registry";
 
-const APP_DIR = fileURLToPath(new URL("../app", import.meta.url));
+const APP_DIR = join(__dirname, "../app");
 
 function collectPageSlugs(dir: string, base = ""): string[] {
   const slugs: string[] = [];

--- a/web-next/tests/page-registry-coverage.test.ts
+++ b/web-next/tests/page-registry-coverage.test.ts
@@ -1,0 +1,53 @@
+/**
+ * クロスカット契約テスト: app/**\/page.tsx と lib/page-registry.ts の双方向一致を機械検証する。
+ *
+ * plans/006 §2.3 が要求する「全 page.tsx が registry に登録済み」を保証し、
+ * 新規ページ追加時の registry 更新漏れ（= 鮮度表示・What's New・sitemap からの脱落）を防ぐ。
+ * 既存の静的検査テスト（tests/phase10.page.test.ts）と同じく node:fs でソースを直接走査する。
+ */
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { pageRegistry } from "@/lib/page-registry";
+
+const APP_DIR = fileURLToPath(new URL("../app", import.meta.url));
+
+function collectPageSlugs(dir: string, base = ""): string[] {
+  const slugs: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      slugs.push(...collectPageSlugs(full, `${base}/${name}`));
+    } else if (name === "page.tsx") {
+      slugs.push(base === "" ? "/" : base);
+    }
+  }
+  return slugs;
+}
+
+const pageSlugs = collectPageSlugs(APP_DIR).sort();
+const registrySlugs = pageRegistry.map((e) => e.slug).sort();
+
+describe("page-registry coverage", () => {
+  it("app 配下に page.tsx が 1 件以上存在する（走査の健全性）", () => {
+    expect(pageSlugs.length).toBeGreaterThan(50);
+  });
+
+  it("全 page.tsx が registry に登録されている（登録漏れ検知）", () => {
+    const missing = pageSlugs.filter((s) => !registrySlugs.includes(s));
+    expect(missing).toEqual([]);
+  });
+
+  it("registry の全 slug に対応する page.tsx が存在する（幽霊エントリ検知）", () => {
+    const ghosts = registrySlugs.filter((s) => !pageSlugs.includes(s));
+    expect(ghosts).toEqual([]);
+  });
+
+  it("registry の各 slug が実ファイルへ解決できる", () => {
+    for (const slug of registrySlugs) {
+      const file = slug === "/" ? join(APP_DIR, "page.tsx") : join(APP_DIR, slug, "page.tsx");
+      expect(existsSync(file), `missing page.tsx for ${slug}`).toBe(true);
+    }
+  });
+});

--- a/web-next/tests/phaseA.layout.test.ts
+++ b/web-next/tests/phaseA.layout.test.ts
@@ -38,6 +38,13 @@ describe("Phase A - layout imports", () => {
       /import\s*\{\s*DisclaimerBanner\s*\}\s*from\s*["']@\/components\/site\/DisclaimerBanner["']/
     );
   });
+
+  // F-1b: 鮮度バッジ（plans/006 §2.3）
+  it("imports PageFreshness from @/components/site/PageFreshness", () => {
+    expect(layoutSrc).toMatch(
+      /import\s*\{\s*PageFreshness\s*\}\s*from\s*["']@\/components\/site\/PageFreshness["']/
+    );
+  });
 });
 
 describe("Phase A - body composition", () => {
@@ -54,6 +61,13 @@ describe("Phase A - body composition", () => {
     const childrenIdx = layoutSrc.indexOf("{children}");
     expect(bannerIdx).toBeGreaterThan(-1);
     expect(bannerIdx).toBeLessThan(childrenIdx);
+  });
+
+  it("renders <PageFreshness /> before {children}", () => {
+    const freshnessIdx = layoutSrc.indexOf("<PageFreshness");
+    const childrenIdx = layoutSrc.indexOf("{children}");
+    expect(freshnessIdx).toBeGreaterThan(-1);
+    expect(freshnessIdx).toBeLessThan(childrenIdx);
   });
 
   it("assigns has-common-header class to <body>", () => {

--- a/web-next/tests/phaseA.nav-links.test.ts
+++ b/web-next/tests/phaseA.nav-links.test.ts
@@ -41,8 +41,9 @@ describe("Phase A - nav-links export shape", () => {
 });
 
 describe("Phase A - nav-links top-level entries", () => {
-  it("has exactly 17 top-level entries", () => {
-    expect(navLinks.length).toBe(17);
+  // F-2 で What's New（フラットリンク）を追加したため 17 → 18。
+  it("has exactly 18 top-level entries", () => {
+    expect(navLinks.length).toBe(18);
   });
 
   it("starts with Home as a flat link", () => {
@@ -52,10 +53,17 @@ describe("Phase A - nav-links top-level entries", () => {
     expect("children" in home).toBe(false);
   });
 
-  it("ends with Git Worktree as a flat link", () => {
+  it("includes Git Worktree as a flat link", () => {
+    const worktree = navLinks.find((link) => link.name === "Git Worktree");
+    expect(worktree).toBeDefined();
+    expect(worktree && "href" in worktree && worktree.href === "/git-worktree").toBe(true);
+  });
+
+  it("ends with What's New as a flat link", () => {
     const last = navLinks[navLinks.length - 1];
-    expect(last.name).toBe("Git Worktree");
-    expect("href" in last && last.href === "/git-worktree").toBe(true);
+    expect(last.name).toBe("What's New");
+    expect("href" in last && last.href === "/whats-new").toBe(true);
+    expect("children" in last).toBe(false);
   });
 
   it("has Claude/Google/Codex/Copilot/Code Review/Agent/MCP/Sandbox/IDE/Security/Local LLM/CI/CD/RAG/Multimodal/LLMOps as dropdowns with children", () => {


### PR DESCRIPTION
主に**「ページレジストリ（`page-registry`）によるメタデータの一元管理」**と、それに伴う機能実装およびインフラ調整が行われています。

---

### **1. ページレジストリの導入と一元管理**

- **`page-registry.ts` の実装** (`9cb7987`)
    - 全ページのメタデータ（タイトル、説明、追加日、最終確認日など）を一元管理するレジストリを導入しました。これにより、各ページとレジストリ登録の整合性を保つための双方向テストもパスするようになっています。

### **2. ページ更新鮮度バッジ (`PageFreshness`) の導入**

- **全ページへの最終確認日バッジの表示** (`9f27ace`, `80c6c63`)
    - レイアウトを介して、すべてのガイドページに最終レビュー日（`last-reviewed`）を示すバッジを自動でレンダリングする仕組みを導入し、テストを実装しました。

### **3. サイトマップ生成の動的化**

- **サイトマップのリファクタリング** (`82d5d94`, `c34738a`)
    - `sitemap.ts` で提供するルート情報を、`page-registry` から動的に導出するように修正し、メタデータと実際のルートの乖離を防ぐ設計にリファクタリングしました。

### **4. 「更新情報 (What's New)」ページの追加**

- **`/whats-new` ページの自動生成** (`9bd22a8`, `029b97f`)
    - `page-registry` に登録された情報から、新着順・更新順で動的にコンテンツを出力する「What's New」ページを追加しました。

### **5. ドキュメントの同期とSEOメタデータの補完**

- **仕様書・計画書の更新** (`a5a81fe`, `993b3e9`, `2e2752e`, `cbf6b04`)
    - Phase 1 の完了を記録し、仕様書の同期や `.gitignore`、月次更新スキルのドキュメントを更新しました。
- **SEOメタデータの修正** (`787c184`, `c723313`)
    - 3つのガイドページで不足していたメタデータを追加し、メタデータ漏れを検知するテストも追加しました。

### **6. ビルドおよび静的解析設定の調整**

- **Netlify ビルド設定の最適化** (`c8a46e9`)
    - ベースディレクトリ（`web-next`）の外部にあるファイル変更時にも適切に変更を反映させるため、常にビルドを実行する設定に修正しました。
- **Sonar 重複検出の除外設定** (`23b81e6`)
    - メタデータ定義が並ぶ `page-registry.ts` が重複コードとして誤検知されるのを防ぐため、Sonar の重複検出対象から除外しました。